### PR TITLE
Make 'hoverable' selectable on end components

### DIFF
--- a/src/containers/CustomPopup.js
+++ b/src/containers/CustomPopup.js
@@ -9,8 +9,7 @@ function CustomPopup(props) {
       // id="suirCalendarPopup"
       hideOnScroll
       on="click"
-      className="suir-calendar popup"
-      hoverable />
+      className="suir-calendar popup"/>
   );
 }
 

--- a/src/containers/inputs/DateInput.d.ts
+++ b/src/containers/inputs/DateInput.d.ts
@@ -9,6 +9,9 @@ export interface DateInputProps {
     /** Position for the popup. */
     popupPosition?: 'top left' | 'top right' | 'bottom left' | 'bottom right' | 'right center' | 'left center' | 'top center' | 'bottom center';
 
+    /** Is hoverable */
+    hoverable?: boolean;
+
     /** A date input can be formatted to appear inline in other content. */
     inline?: boolean;
 

--- a/src/containers/inputs/DateInput.d.ts
+++ b/src/containers/inputs/DateInput.d.ts
@@ -9,8 +9,8 @@ export interface DateInputProps {
     /** Position for the popup. */
     popupPosition?: 'top left' | 'top right' | 'bottom left' | 'bottom right' | 'right center' | 'left center' | 'top center' | 'bottom center';
 
-    /** Is hoverable */
-    hoverable?: boolean;
+    /** Should close when cursor leaves calendar popup */
+    closeOnMouseLeave?: boolean;
 
     /** A date input can be formatted to appear inline in other content. */
     inline?: boolean;

--- a/src/containers/inputs/DateInput.js
+++ b/src/containers/inputs/DateInput.js
@@ -82,7 +82,8 @@ class DateInput extends YearPickerMixin {
       icon,
       popupPosition,
       inline,
-      value
+      value,
+      hoverable
     } = this.props;
     const rest = getUnhandledProps(DateInput, this.props);
     
@@ -102,7 +103,8 @@ class DateInput extends YearPickerMixin {
     return (
       <Popup
         position={popupPosition}
-        trigger={inputElement}>
+        trigger={inputElement}
+        hoverable={hoverable}>
         { this.getPicker() }
       </Popup>
     );
@@ -115,13 +117,15 @@ DateInput.propTypes = {
   popupPosition: CustomPropTypes.popupPosition,
   inline: PropTypes.bool,
   value: PropTypes.string,
-  wrapperState: CustomPropTypes.wrapperState
+  wrapperState: CustomPropTypes.wrapperState,
+  hoverable: PropTypes.bool
 };
 
 DateInput.defaultProps = {
   icon: 'calendar',
   inline: false,
-  value: ''
+  value: '',
+  hoverable: true
 };
 
 const WrappedDateInput = withStateInput(DateInput);

--- a/src/containers/inputs/DateInput.js
+++ b/src/containers/inputs/DateInput.js
@@ -83,7 +83,7 @@ class DateInput extends YearPickerMixin {
       popupPosition,
       inline,
       value,
-      hoverable
+      closeOnMouseLeave
     } = this.props;
     const rest = getUnhandledProps(DateInput, this.props);
     
@@ -104,7 +104,7 @@ class DateInput extends YearPickerMixin {
       <Popup
         position={popupPosition}
         trigger={inputElement}
-        hoverable={hoverable}>
+        hoverable={closeOnMouseLeave}>
         { this.getPicker() }
       </Popup>
     );
@@ -118,14 +118,14 @@ DateInput.propTypes = {
   inline: PropTypes.bool,
   value: PropTypes.string,
   wrapperState: CustomPropTypes.wrapperState,
-  hoverable: PropTypes.bool
+  closeOnMouseLeave: PropTypes.bool
 };
 
 DateInput.defaultProps = {
   icon: 'calendar',
   inline: false,
   value: '',
-  hoverable: true
+  closeOnMouseLeave: true
 };
 
 const WrappedDateInput = withStateInput(DateInput);

--- a/src/containers/inputs/DateTimeInput.d.ts
+++ b/src/containers/inputs/DateTimeInput.d.ts
@@ -17,6 +17,9 @@ export interface DateTimeInputProps {
     /** Position for the popup. */
     popupPosition?: 'top left' | 'top right' | 'bottom left' | 'bottom right' | 'right center' | 'left center' | 'top center' | 'bottom center';
 
+    /** Is hoverable */
+    hoverable?: boolean;
+    
     /** A date time input can be formatted to appear inline in other content. */
     inline?: boolean;
 

--- a/src/containers/inputs/DateTimeInput.d.ts
+++ b/src/containers/inputs/DateTimeInput.d.ts
@@ -17,8 +17,8 @@ export interface DateTimeInputProps {
     /** Position for the popup. */
     popupPosition?: 'top left' | 'top right' | 'bottom left' | 'bottom right' | 'right center' | 'left center' | 'top center' | 'bottom center';
 
-    /** Is hoverable */
-    hoverable?: boolean;
+    /** Should close when cursor leaves calendar popup */
+    closeOnMouseLeave?: boolean;
     
     /** A date time input can be formatted to appear inline in other content. */
     inline?: boolean;

--- a/src/containers/inputs/DateTimeInput.js
+++ b/src/containers/inputs/DateTimeInput.js
@@ -97,7 +97,7 @@ class DateTimeInput extends YearPickerMixin {
       popupPosition,
       inline,
       value,
-      hoverable
+      closeOnMouseLeave
     } = this.props;
     const rest = getUnhandledProps(DateTimeInput, this.props);
 
@@ -117,7 +117,7 @@ class DateTimeInput extends YearPickerMixin {
       <Popup
         position={popupPosition}
         trigger={inputElement}
-        hoverable={hoverable}>
+        hoverable={closeOnMouseLeave}>
         { this.getPicker() }
       </Popup>
     );
@@ -136,14 +136,14 @@ DateTimeInput.propTypes = {
   inline: PropTypes.bool,
   value: PropTypes.string,
   wrapperState: CustomPropTypes.wrapperState,
-  hoverable: PropTypes.bool
+  closeOnMouseLeave: PropTypes.bool
 };
 
 DateTimeInput.defaultProps = {
   icon: 'calendar',
   inline: false,
   value: '',
-  hoverable: true
+  closeOnMouseLeave: true
 };
 
 const WrappedDateTimeInput = withStateInput(DateTimeInput);

--- a/src/containers/inputs/DateTimeInput.js
+++ b/src/containers/inputs/DateTimeInput.js
@@ -96,7 +96,8 @@ class DateTimeInput extends YearPickerMixin {
       icon,
       popupPosition,
       inline,
-      value
+      value,
+      hoverable
     } = this.props;
     const rest = getUnhandledProps(DateTimeInput, this.props);
 
@@ -115,7 +116,8 @@ class DateTimeInput extends YearPickerMixin {
     return (
       <Popup
         position={popupPosition}
-        trigger={inputElement}>
+        trigger={inputElement}
+        hoverable={hoverable}>
         { this.getPicker() }
       </Popup>
     );
@@ -133,13 +135,15 @@ DateTimeInput.propTypes = {
   popupPosition: CustomPropTypes.popupPosition,
   inline: PropTypes.bool,
   value: PropTypes.string,
-  wrapperState: CustomPropTypes.wrapperState
+  wrapperState: CustomPropTypes.wrapperState,
+  hoverable: PropTypes.bool
 };
 
 DateTimeInput.defaultProps = {
   icon: 'calendar',
   inline: false,
-  value: ''
+  value: '',
+  hoverable: true
 };
 
 const WrappedDateTimeInput = withStateInput(DateTimeInput);

--- a/src/containers/inputs/DatesRangeInput.d.ts
+++ b/src/containers/inputs/DatesRangeInput.d.ts
@@ -17,6 +17,9 @@ export interface DatesRangeInputProps {
     /** Position for the popup. */
     popupPosition?: 'top left' | 'top right' | 'bottom left' | 'bottom right' | 'right center' | 'left center' | 'top center' | 'bottom center';
 
+    /** Is hoverable */
+    hoverable?: boolean;
+    
     /** A dates range input can be formatted to appear inline in other content. */
     inline?: boolean;
 }

--- a/src/containers/inputs/DatesRangeInput.d.ts
+++ b/src/containers/inputs/DatesRangeInput.d.ts
@@ -17,8 +17,8 @@ export interface DatesRangeInputProps {
     /** Position for the popup. */
     popupPosition?: 'top left' | 'top right' | 'bottom left' | 'bottom right' | 'right center' | 'left center' | 'top center' | 'bottom center';
 
-    /** Is hoverable */
-    hoverable?: boolean;
+    /** Should close when cursor leaves calendar popup */
+    closeOnMouseLeave?: boolean;
     
     /** A dates range input can be formatted to appear inline in other content. */
     inline?: boolean;

--- a/src/containers/inputs/DatesRangeInput.js
+++ b/src/containers/inputs/DatesRangeInput.js
@@ -50,7 +50,8 @@ class DatesRangeInput extends React.Component {
       onChange,
       icon,
       popupPosition,
-      inline
+      inline,
+      hoverable
     } = this.props;
     
     const rest = getUnhandledProps(DatesRangeInput, this.props);
@@ -68,7 +69,8 @@ class DatesRangeInput extends React.Component {
     return (
       <Popup
         position={popupPosition}
-        trigger={inputElement}>
+        trigger={inputElement}
+        hoverable={hoverable}>
         { this.getPicker() }
       </Popup>
     );
@@ -86,12 +88,14 @@ DatesRangeInput.propTypes = {
   /** Character that used to divide dates in string. */
   popupPosition: CustomPropTypes.popupPosition,
   inline: PropTypes.bool,
-  wrapperState: CustomPropTypes.wrapperState
+  wrapperState: CustomPropTypes.wrapperState,
+  hoverable: PropTypes.bool
 };
 
 DatesRangeInput.defaultProps = {
   icon: 'calendar',
-  inline: false
+  inline: false,
+  hoverable: true
 };
 
 const WrappedDatesRangeInput = withStateInput(DatesRangeInput);

--- a/src/containers/inputs/DatesRangeInput.js
+++ b/src/containers/inputs/DatesRangeInput.js
@@ -51,7 +51,7 @@ class DatesRangeInput extends React.Component {
       icon,
       popupPosition,
       inline,
-      hoverable
+      closeOnMouseLeave
     } = this.props;
     
     const rest = getUnhandledProps(DatesRangeInput, this.props);
@@ -70,7 +70,7 @@ class DatesRangeInput extends React.Component {
       <Popup
         position={popupPosition}
         trigger={inputElement}
-        hoverable={hoverable}>
+        hoverable={closeOnMouseLeave}>
         { this.getPicker() }
       </Popup>
     );
@@ -89,13 +89,13 @@ DatesRangeInput.propTypes = {
   popupPosition: CustomPropTypes.popupPosition,
   inline: PropTypes.bool,
   wrapperState: CustomPropTypes.wrapperState,
-  hoverable: PropTypes.bool
+  closeOnMouseLeave: PropTypes.bool
 };
 
 DatesRangeInput.defaultProps = {
   icon: 'calendar',
   inline: false,
-  hoverable: true
+  closeOnMouseLeave: true
 };
 
 const WrappedDatesRangeInput = withStateInput(DatesRangeInput);

--- a/src/containers/inputs/MonthInput.d.ts
+++ b/src/containers/inputs/MonthInput.d.ts
@@ -17,8 +17,8 @@ export interface MonthInputProps {
     /** Position for the popup. */
     popupPosition?: 'top left' | 'top right' | 'bottom left' | 'bottom right' | 'right center' | 'left center' | 'top center' | 'bottom center';
 
-    /** Is hoverable */
-    hoverable?: boolean;
+    /** Should close when cursor leaves calendar popup */
+    closeOnMouseLeave?: boolean;
 
     /** A month input can be formatted to appear inline in other content. */
     inline?: boolean;

--- a/src/containers/inputs/MonthInput.d.ts
+++ b/src/containers/inputs/MonthInput.d.ts
@@ -17,6 +17,9 @@ export interface MonthInputProps {
     /** Position for the popup. */
     popupPosition?: 'top left' | 'top right' | 'bottom left' | 'bottom right' | 'right center' | 'left center' | 'top center' | 'bottom center';
 
+    /** Is hoverable */
+    hoverable?: boolean;
+
     /** A month input can be formatted to appear inline in other content. */
     inline?: boolean;
 

--- a/src/containers/inputs/MonthInput.js
+++ b/src/containers/inputs/MonthInput.js
@@ -59,7 +59,8 @@ class MonthInput extends React.Component {
       icon,
       popupPosition,
       inline,
-      value
+      value,
+      hoverable
     } = this.props;
     
     const rest = getUnhandledProps(MonthInput, this.props);
@@ -77,7 +78,8 @@ class MonthInput extends React.Component {
     return (
       <Popup
         position={popupPosition}
-        trigger={inputElement}>
+        trigger={inputElement}
+        hoverable={hoverable}>
         { this.getPicker() }
       </Popup>
     );
@@ -96,14 +98,16 @@ MonthInput.propTypes = {
   inline: PropTypes.bool,
   value: PropTypes.string,
   /* If true, popup closes after selecting a date/time */
-  closable: PropTypes.bool
+  closable: PropTypes.bool,
+  hoverable: PropTypes.bool
 };
 
 MonthInput.defaultProps = {
   icon: 'calendar',
   inline: false,
   value: '',
-  closable: false
+  closable: false,
+  hoverable: true
 };
 
 export default MonthInput;

--- a/src/containers/inputs/MonthInput.js
+++ b/src/containers/inputs/MonthInput.js
@@ -60,7 +60,7 @@ class MonthInput extends React.Component {
       popupPosition,
       inline,
       value,
-      hoverable
+      closeOnMouseLeave
     } = this.props;
     
     const rest = getUnhandledProps(MonthInput, this.props);
@@ -79,7 +79,7 @@ class MonthInput extends React.Component {
       <Popup
         position={popupPosition}
         trigger={inputElement}
-        hoverable={hoverable}>
+        hoverable={closeOnMouseLeave}>
         { this.getPicker() }
       </Popup>
     );
@@ -99,7 +99,7 @@ MonthInput.propTypes = {
   value: PropTypes.string,
   /* If true, popup closes after selecting a date/time */
   closable: PropTypes.bool,
-  hoverable: PropTypes.bool
+  closeOnMouseLeave: PropTypes.bool
 };
 
 MonthInput.defaultProps = {
@@ -107,7 +107,7 @@ MonthInput.defaultProps = {
   inline: false,
   value: '',
   closable: false,
-  hoverable: true
+  closeOnMouseLeave: true
 };
 
 export default MonthInput;

--- a/src/containers/inputs/TimeInput.d.ts
+++ b/src/containers/inputs/TimeInput.d.ts
@@ -17,8 +17,8 @@ export interface TimeInputProps {
     /** Position for the popup. */
     popupPosition?: 'top left' | 'top right' | 'bottom left' | 'bottom right' | 'right center' | 'left center' | 'top center' | 'bottom center';
  
-    /** Is hoverable */
-    hoverable?: boolean;
+    /** Should close when cursor leaves calendar popup */
+    closeOnMouseLeave?: boolean;
 
     /** A time input can be formatted to appear inline in other content. */
     inline?: boolean;

--- a/src/containers/inputs/TimeInput.d.ts
+++ b/src/containers/inputs/TimeInput.d.ts
@@ -16,6 +16,9 @@ export interface TimeInputProps {
 
     /** Position for the popup. */
     popupPosition?: 'top left' | 'top right' | 'bottom left' | 'bottom right' | 'right center' | 'left center' | 'top center' | 'bottom center';
+ 
+    /** Is hoverable */
+    hoverable?: boolean;
 
     /** A time input can be formatted to appear inline in other content. */
     inline?: boolean;

--- a/src/containers/inputs/TimeInput.js
+++ b/src/containers/inputs/TimeInput.js
@@ -91,7 +91,8 @@ class TimeInput extends React.Component {
       icon,
       popupPosition,
       inline,
-      value
+      value,
+      hoverable
     } = this.props;
     const rest = getUnhandledProps(TimeInput, this.props);
   
@@ -109,7 +110,8 @@ class TimeInput extends React.Component {
       <Popup
         onClose={this.onPopupClose}
         position={popupPosition}
-        trigger={inputElement}>
+        trigger={inputElement}
+        hoverable={hoverable}>
         { this.getPicker() }
       </Popup>
     );
@@ -128,14 +130,16 @@ TimeInput.propTypes = {
   inline: PropTypes.bool,
   value: PropTypes.string,
   /* If true, popup closes after selecting a date/time */
-  closable: PropTypes.bool
+  closable: PropTypes.bool,
+  hoverable: PropTypes.bool
 };
 
 TimeInput.defaultProps = {
   icon: 'time',
   inline: false,
   value: '',
-  closable: false
+  closable: false,
+  hoverable: true
 };
 
 export default TimeInput;

--- a/src/containers/inputs/TimeInput.js
+++ b/src/containers/inputs/TimeInput.js
@@ -92,7 +92,7 @@ class TimeInput extends React.Component {
       popupPosition,
       inline,
       value,
-      hoverable
+      closeOnMouseLeave
     } = this.props;
     const rest = getUnhandledProps(TimeInput, this.props);
   
@@ -111,7 +111,7 @@ class TimeInput extends React.Component {
         onClose={this.onPopupClose}
         position={popupPosition}
         trigger={inputElement}
-        hoverable={hoverable}>
+        hoverable={closeOnMouseLeave}>
         { this.getPicker() }
       </Popup>
     );
@@ -131,7 +131,7 @@ TimeInput.propTypes = {
   value: PropTypes.string,
   /* If true, popup closes after selecting a date/time */
   closable: PropTypes.bool,
-  hoverable: PropTypes.bool
+  closeOnMouseLeave: PropTypes.bool
 };
 
 TimeInput.defaultProps = {
@@ -139,7 +139,7 @@ TimeInput.defaultProps = {
   inline: false,
   value: '',
   closable: false,
-  hoverable: true
+  closeOnMouseLeave: true
 };
 
 export default TimeInput;

--- a/src/containers/inputs/YearInput.d.ts
+++ b/src/containers/inputs/YearInput.d.ts
@@ -17,6 +17,9 @@ export interface YearInputProps {
     /** Position for the popup. */
     popupPosition?: 'top left' | 'top right' | 'bottom left' | 'bottom right' | 'right center' | 'left center' | 'top center' | 'bottom center';
 
+    /** Is hoverable */
+    hoverable?: boolean;
+
     /** A year input can be formatted to appear inline in other content. */
     inline?: boolean;
 

--- a/src/containers/inputs/YearInput.d.ts
+++ b/src/containers/inputs/YearInput.d.ts
@@ -17,8 +17,8 @@ export interface YearInputProps {
     /** Position for the popup. */
     popupPosition?: 'top left' | 'top right' | 'bottom left' | 'bottom right' | 'right center' | 'left center' | 'top center' | 'bottom center';
 
-    /** Is hoverable */
-    hoverable?: boolean;
+    /** Should close when cursor leaves calendar popup */
+    closeOnMouseLeave?: boolean;
 
     /** A year input can be formatted to appear inline in other content. */
     inline?: boolean;

--- a/src/containers/inputs/YearInput.js
+++ b/src/containers/inputs/YearInput.js
@@ -71,7 +71,7 @@ class YearInput extends YearPickerMixin {
       popupPosition,
       inline,
       value,
-      hoverable
+      closeOnMouseLeave
     } = this.props;
     const rest = getUnhandledProps(YearInput, this.props);
   
@@ -89,7 +89,7 @@ class YearInput extends YearPickerMixin {
       <Popup
         position={popupPosition}
         trigger={inputElement}
-        hoverable={hoverable}>
+        hoverable={closeOnMouseLeave}>
         { this.getPicker() }
       </Popup>
     );
@@ -109,7 +109,7 @@ YearInput.propTypes = {
   value: PropTypes.string,
   /* If true, popup closes after selecting a date/time */
   closable: PropTypes.bool,
-  hoverable: PropTypes.bool
+  closeOnMouseLeave: PropTypes.bool
 };
 
 YearInput.defaultProps = {
@@ -117,7 +117,7 @@ YearInput.defaultProps = {
   inline: false,
   value: '',
   closable: false,
-  hoverable: true
+  closeOnMouseLeave: true
 };
 
 export default YearInput;

--- a/src/containers/inputs/YearInput.js
+++ b/src/containers/inputs/YearInput.js
@@ -70,7 +70,8 @@ class YearInput extends YearPickerMixin {
       icon,
       popupPosition,
       inline,
-      value
+      value,
+      hoverable
     } = this.props;
     const rest = getUnhandledProps(YearInput, this.props);
   
@@ -87,7 +88,8 @@ class YearInput extends YearPickerMixin {
     return (
       <Popup
         position={popupPosition}
-        trigger={inputElement}>
+        trigger={inputElement}
+        hoverable={hoverable}>
         { this.getPicker() }
       </Popup>
     );
@@ -106,14 +108,16 @@ YearInput.propTypes = {
   inline: PropTypes.bool,
   value: PropTypes.string,
   /* If true, popup closes after selecting a date/time */
-  closable: PropTypes.bool
+  closable: PropTypes.bool,
+  hoverable: PropTypes.bool
 };
 
 YearInput.defaultProps = {
   icon: 'calendar',
   inline: false,
   value: '',
-  closable: false
+  closable: false,
+  hoverable: true
 };
 
 export default YearInput;


### PR DESCRIPTION
Can be useful to be able to have calendar open even after it is no longer hovered. Leave default at 'true' as before