### PR TITLE
Allow passthrough of mountNode to InputView Popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ moment.locale('ru');
 | ``inlineLabel`` | {bool} A field can have its label next to instead of above it. |
 | ``closeOnMouseLeave`` | {bool} Should close when cursor leaves calendar popup. Default: ``true`` |
 | ``preserveViewMode`` | {bool} Preserve last mode (`day`, `hour`, `minute`) each time user opens dialog. Default ``true`` |
+| ``mountNode`` | {any} The node where the picker should mount. |
 
 ### TimeInput
 
@@ -146,6 +147,7 @@ moment.locale('ru');
 | ``inlineLabel`` | {bool} A field can have its label next to instead of above it. |
 | ``closeOnMouseLeave`` | {bool} Should close when cursor leaves calendar popup. Default: ``true`` |
 | ``timeFormat`` | {string} One of ["24", "AMPM", "ampm"]. Default: ``"24"`` |
+| ``mountNode`` | {any} The node where the picker should mount. |
 
 ### DateTimeInput
 
@@ -166,6 +168,7 @@ moment.locale('ru');
 | ``closeOnMouseLeave`` | {bool} Should close when cursor leaves calendar popup. Default: ``true`` |
 | ``timeFormat`` | {string} One of ["24", "AMPM", "ampm"]. Default: ``"24"`` |
 | ``preserveViewMode`` | {bool} Preserve last mode (`day`, `hour`, `minute`) each time user opens dialog. Default ``true`` |
+| ``mountNode`` | {any} The node where the picker should mount. |
 
 ### DatesRangeInput
 
@@ -181,6 +184,7 @@ moment.locale('ru');
 | ``minDate`` | {string\|moment} Minimum date that can be selected |
 | ``inlineLabel`` | {bool} A field can have its label next to instead of above it. |
 | ``closeOnMouseLeave`` | {bool} Should close when cursor leaves calendar popup. Default: ``true`` |
+| ``mountNode`` | {any} The node where the picker should mount. |
 
 ### YearInput
 
@@ -192,6 +196,7 @@ moment.locale('ru');
 | ``closable`` | {bool} If true, popup closes after selecting a year   |
 | ``inlineLabel`` | {bool} A field can have its label next to instead of above it. |
 | ``closeOnMouseLeave`` | {bool} Should close when cursor leaves calendar popup. Default: ``true`` |
+| ``mountNode`` | {any} The node where the picker should mount. |
 
 ### MonthInput
 
@@ -207,3 +212,4 @@ moment.locale('ru');
 | ``disable`` | {string\|Moment\|Date\|string[]\|Moment[]\|Date[]} Date or list of dates that are displayed as disabled. |
 | ``maxDate`` | {string\|Moment\|Date\|string[]\|Moment[]\|Date[]} Maximum date that can be selected. |
 | ``minDate`` | {string\|Moment\|Date\|string[]\|Moment[]\|Date[]} Minimum date that can be selected. |
+| ``mountNode`` | {any} The node where the picker should mount. |

--- a/src/views/InputView.js
+++ b/src/views/InputView.js
@@ -18,9 +18,10 @@ function InputView(props) {
     inlineLabel,
     popupIsClosed,
     onPopupUnmount,
+    mountNode,
   } = props;
   const rest = getUnhandledProps(InputView, props);
-  
+
   const inputElement = (
     <Form.Input
       { ...rest }
@@ -37,10 +38,12 @@ function InputView(props) {
       trigger={inputElement}
       hoverable={closeOnMouseLeave}
       flowing
+      mountNode={mountNode}
       onUnmount={onPopupUnmount}
       style={popupStyle}
       hideOnScroll
-      on="click">
+      on="click"
+    >
       { props.children }
     </Popup>
   );
@@ -65,6 +68,8 @@ InputView.propTypes = {
   popupIsClosed: PropTypes.bool,
   /** Called when popup is forsed to close. */
   onPopupUnmount: PropTypes.func,
+  /** The node where the picker should mount. */
+  mountNode: PropTypes.any,
 };
 
 InputView.defaultProps = {


### PR DESCRIPTION
Since the picker is built inside of a Semantic UI Popup, it makes sense to be able to choose the mountNode for the picker just as you would for a regular Popup.

This PR makes it possible to pass a mountNode through any of the input views down to the Popup.