### PR TITLE
Add dateTimeFormat prop to DateTimePicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,9 @@ moment.locale('ru');
 | Prop | Description |
 | -----| ------------|
 | all that can be used with SUIR Form.Input | |
-| ``dateFormat``| {string} Date formatting string. You can use here anything that can be passed to ``moment().format``. Default: ``DD-MM-YYYY``|
+| ``dateTimeFormat`` | {string} Datetime formatting string. You can use any string here that can be passed to ``moment().format``. If provided, it overrides ``dateFormat``, ``divider``, and ``timeFormat``. Default: ``null`` |
+| ``dateFormat``| {string} Date formatting string. You can use any string here that can be passed to ``moment().format``. Default: ``DD-MM-YYYY``. This formats only the date component of the datetime. |
+| ``timeFormat`` | {string} One of ["24", "AMPM", "ampm"]. Default: ``"24"`` |
 | ``divider`` | {string} Date and time divider. Default: `` `` |
 | ``popupPosition``| {string} One of ['top left', 'top right', 'bottom left', 'bottom right', 'right center', 'left center', 'top center', 'bottom center']. Default: ``top left``|
 | ``inline`` | {bool} If ``true`` inline picker displayed. Default: ``false`` |

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ moment.locale('ru');
 | Prop | Description |
 | -----| ------------|
 | all that can be used with SUIR Form.Input | |
-| ``dateTimeFormat`` | {string} Datetime formatting string. You can use any string here that can be passed to ``moment().format``. If provided, it overrides ``dateFormat``, ``divider``, and ``timeFormat``. Default: ``null`` |
+| ``dateTimeFormat`` | {string} Datetime formatting string for the input's `value`. You can use any string here that can be passed to ``moment().format``. If provided, it overrides ``dateFormat``, ``divider``, and ``timeFormat``. **Note:** this does not affect the formats used to display the pop-up date and time pickers; it only affects the format of the input's `value` field. Default: ``null`` |
 | ``dateFormat``| {string} Date formatting string. You can use any string here that can be passed to ``moment().format``. Default: ``DD-MM-YYYY``. This formats only the date component of the datetime. |
 | ``timeFormat`` | {string} One of ["24", "AMPM", "ampm"]. Default: ``"24"`` |
 | ``divider`` | {string} Date and time divider. Default: `` `` |

--- a/src/inputs/DateTimeInput.d.ts
+++ b/src/inputs/DateTimeInput.d.ts
@@ -38,6 +38,9 @@ export interface DateTimeInputProps {
   /** Current value. Creates a controlled component. */
   value?: string;
 
+  /** Datetime formatting string. */
+  dateTimeFormat?: string;
+
   /** Date formatting string. */
   dateFormat?: string;
 

--- a/src/inputs/DateTimeInput.js
+++ b/src/inputs/DateTimeInput.js
@@ -84,7 +84,9 @@ class DateTimeInput extends BaseInput {
       dateFormat,
       divider,
       timeFormat,
+      dateTimeFormat
     } = this.props;
+    if (dateTimeFormat) return dateTimeFormat;
     return `${dateFormat}${divider}${TIME_FORMAT[timeFormat]}`;
   }
 
@@ -198,6 +200,8 @@ class DateTimeInput extends BaseInput {
 DateTimeInput.propTypes = {
   /** Currently selected value. */
   value: PropTypes.string,
+  /** Moment datetime formatting string */
+  dateTimeFormat: PropTypes.string,
   /** Moment date formatting string. */
   dateFormat: PropTypes.string,
   /** Time format ["AMPM", "ampm", "24"] */

--- a/src/inputs/DateTimeInput.js
+++ b/src/inputs/DateTimeInput.js
@@ -86,8 +86,7 @@ class DateTimeInput extends BaseInput {
       timeFormat,
       dateTimeFormat
     } = this.props;
-    if (dateTimeFormat) return dateTimeFormat;
-    return `${dateFormat}${divider}${TIME_FORMAT[timeFormat]}`;
+    return dateTimeFormat || `${dateFormat}${divider}${TIME_FORMAT[timeFormat]}`;
   }
 
   getPicker() {


### PR DESCRIPTION
First of all, thank you for your good work! This is an easy, drop-in component that looks great. Appreciate the CSS-free version too, makes it even easier.

I did run into trouble trying to use the DateTimePicker component for fields stored as unix timestamps. Because the dateformat and timeformat are specified separately, it appends the time to the end of the value like: `1539092100 22:22`, and while the divider can be set to null there's no way to null out the timeFormat. 

This change is backwards-compatible and allows users to specify the entire format string, not just the date part of it. Since moment format strings can have escaped characters, this allows the same flexibility to add custom dividers and allows more time formats too (including time zone code, for example, or without a `:`). 

It's an optional prop, and if not specified there is no change to behavior.

Updated the documentation as well.

`npm test` passed, although I didn't see a DateTime component test. If there's anything else I can add, please let me know.