### PR TITLE
Add clearable props to Input

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ npm i semantic-ui-calendar-react
 Let's create a form that needs date-related input fields.
 
 Import input components:
+
 ```javascript
 import {
   DateInput,
@@ -26,6 +27,7 @@ import {
 } from 'semantic-ui-calendar-react';
 ```
 Then build a form:
+
 ```javascript
 class DateTimeForm extends React.Component {
   constructor(props) {
@@ -53,25 +55,29 @@ class DateTimeForm extends React.Component {
           placeholder="Date"
           value={this.state.date}
           iconPosition="left"
-          onChange={this.handleChange} />
+          onChange={this.handleChange}
+        />
         <TimeInput
           name="time"
           placeholder="Time"
           value={this.state.time}
           iconPosition="left"
-          onChange={this.handleChange} />
+          onChange={this.handleChange}
+        />
         <DateTimeInput
           name="dateTime"
           placeholder="Date Time"
           value={this.state.dateTime}
           iconPosition="left"
-          onChange={this.handleChange} />
+          onChange={this.handleChange}
+        />
         <DatesRangeInput
           name="datesRange"
           placeholder="From - To"
           value={this.state.datesRange}
           iconPosition="left"
-          onChange={this.handleChange} />
+          onChange={this.handleChange}
+        />
       </Form>
     );
   }
@@ -79,6 +85,7 @@ class DateTimeForm extends React.Component {
 ```
 
 Also you can build a form with inline pickers as inputs. Just set ``inline`` prop on input element and it will be displayed as inline picker:
+
 ```javascript
 class DateTimeFormInline extends React.Component {
  handleChange = (event, {name, value}) => {
@@ -92,9 +99,36 @@ class DateTimeFormInline extends React.Component {
       <Form>
         <DateInput
           inline
+          name='date'
+          value={this.state.date}
+          onChange={this.handleDateChange}
+        />
+      </Form>
+    );
+  }
+}
+```
+
+or you can make it cleanable in the following way,
+
+```javascript
+class ClearableDateTimeForm extends React.Component {
+  handleChange = (event, {name, value}) => {
+    if (this.state.hasOwnProperty(name)) {
+      this.setState({ [name]: value });
+    }
+  }
+
+  render() {
+    return (
+      <Form>
+        <DateInput
+          clearable
+          clearIcon={<Icon name="remove" color="red" />}
           name="date"
           value={this.state.date}
-          onChange={this.handleDateChange} />
+          onChange={this.handleDateChange}
+        />
       </Form>
     );
   }
@@ -136,6 +170,9 @@ moment.locale('ru');
 | ``closeOnMouseLeave`` | {bool} Should close when cursor leaves calendar popup. Default: ``true`` |
 | ``preserveViewMode`` | {bool} Preserve last mode (`day`, `hour`, `minute`) each time user opens dialog. Default ``true`` |
 | ``mountNode`` | {any} The node where the picker should mount. |
+| ``onClear`` | {func} Called after clear icon has clicked. |
+| ``clearable`` | {boolean} Using the clearable setting will let users remove their selection from a calendar. |
+| ``clearIcon`` | {any} Optional Icon to display inside the clearable Input. |
 
 ### TimeInput
 
@@ -150,6 +187,9 @@ moment.locale('ru');
 | ``timeFormat`` | {string} One of ["24", "AMPM", "ampm"]. Default: ``"24"`` |
 | ``disableMinute`` | {bool} If ``true``, minutes picker won't be shown after picking the hour. Default: ``false`` |
 | ``mountNode`` | {any} The node where the picker should mount. |
+| ``onClear`` | {func} Called after clear icon has clicked. |
+| ``clearable`` | {boolean} Using the clearable setting will let users remove their selection from a calendar. |
+| ``clearIcon`` | {any} Optional Icon to display inside the clearable Input. |
 
 ### DateTimeInput
 
@@ -173,6 +213,9 @@ moment.locale('ru');
 | ``timeFormat`` | {string} One of ["24", "AMPM", "ampm"]. Default: ``"24"`` |
 | ``preserveViewMode`` | {bool} Preserve last mode (`day`, `hour`, `minute`) each time user opens dialog. Default ``true`` |
 | ``mountNode`` | {any} The node where the picker should mount. |
+| ``onClear`` | {func} Called after clear icon has clicked. |
+| ``clearable`` | {boolean} Using the clearable setting will let users remove their selection from a calendar. |
+| ``clearIcon`` | {any} Optional Icon to display inside the clearable Input. |
 
 ### DatesRangeInput
 
@@ -189,6 +232,9 @@ moment.locale('ru');
 | ``inlineLabel`` | {bool} A field can have its label next to instead of above it. |
 | ``closeOnMouseLeave`` | {bool} Should close when cursor leaves calendar popup. Default: ``true`` |
 | ``mountNode`` | {any} The node where the picker should mount. |
+| ``onClear`` | {func} Called after clear icon has clicked. |
+| ``clearable`` | {boolean} Using the clearable setting will let users remove their selection from a calendar. |
+| ``clearIcon`` | {any} Optional Icon to display inside the clearable Input. |
 
 ### YearInput
 
@@ -201,6 +247,9 @@ moment.locale('ru');
 | ``inlineLabel`` | {bool} A field can have its label next to instead of above it. |
 | ``closeOnMouseLeave`` | {bool} Should close when cursor leaves calendar popup. Default: ``true`` |
 | ``mountNode`` | {any} The node where the picker should mount. |
+| ``onClear`` | {func} Called after clear icon has clicked. |
+| ``clearable`` | {boolean} Using the clearable setting will let users remove their selection from a calendar. |
+| ``clearIcon`` | {any} Optional Icon to display inside the clearable Input. |
 
 ### MonthInput
 
@@ -217,3 +266,6 @@ moment.locale('ru');
 | ``maxDate`` | {string\|Moment\|Date\|string[]\|Moment[]\|Date[]} Maximum date that can be selected. |
 | ``minDate`` | {string\|Moment\|Date\|string[]\|Moment[]\|Date[]} Minimum date that can be selected. |
 | ``mountNode`` | {any} The node where the picker should mount. |
+| ``onClear`` | {func} Called after clear icon has clicked. |
+| ``clearable`` | {boolean} Using the clearable setting will let users remove their selection from a calendar. |
+| ``clearIcon`` | {any} Optional Icon to display inside the clearable Input. |

--- a/example/calendar.tsx
+++ b/example/calendar.tsx
@@ -1,7 +1,12 @@
 import * as moment from 'moment';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { Form } from 'semantic-ui-react';
+import {
+  Checkbox,
+  Form,
+  Header,
+  Icon,
+} from 'semantic-ui-react';
 
 import {
   DateInput,
@@ -27,15 +32,42 @@ type DateTimeFormHandleChangeData = DateInputOnChangeData
   | TimeInputOnChangeData
   | YearInputOnChangeData;
 
-function App() {
-  return (
-    <div className='example-calendar-container'>
-      <h2>As text fields</h2>
-      <DateTimeForm />
-      <h2>Inline</h2>
-      <DateTimeFormInline />
-    </div>
-  );
+class App extends React.Component<any, any> {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      clearable: false,
+    };
+  }
+
+  handleCheckboxChange() {
+    this.setState(() => ({
+      clearable: !this.state.clearable,
+    }))
+  }
+
+  public render() {
+    return (
+      <div className='example-calendar-container'>
+        <Header as='h2' dividing>
+          As text fields
+          <Header.Subheader>
+            <Checkbox
+              label='Make data inputs clearable'
+              checked={this.state.clearable}
+              onChange={this.handleCheckboxChange.bind(this)}
+            />
+          </Header.Subheader>
+        </Header>
+
+        <DateTimeForm clearable={this.state.clearable}
+      />
+        <h2>Inline</h2>
+        <DateTimeFormInline />
+      </div>
+    );
+  }
 }
 
 class DateTimeForm extends React.Component<any, any> {
@@ -54,6 +86,8 @@ class DateTimeForm extends React.Component<any, any> {
   }
 
   public render() {
+    const { clearable } = this.props
+
     return (
       <Form>
         <DateInput
@@ -61,11 +95,14 @@ class DateTimeForm extends React.Component<any, any> {
           popupPosition='bottom right'
           className='example-calendar-input'
           name='date'
+          clearIcon={(<Icon name='remove' color='red' />)}
+          clearable={clearable}
           value={this.state.date}
           iconPosition='left'
           preserveViewMode={false}
           autoComplete='off'
-          onChange={this.handleChange} />
+          onChange={this.handleChange}
+        />
         <br />
         <DateInput
           startMode='year'
@@ -73,11 +110,13 @@ class DateTimeForm extends React.Component<any, any> {
           placeholder='Date startMode year'
           className='example-calendar-input'
           name='dateStartYear'
+          clearable={clearable}
           value={this.state.dateStartYear}
           iconPosition='left'
           autoComplete='off'
           preserveViewMode={false}
-          onChange={this.handleChange} />
+          onChange={this.handleChange}
+        />
         <br />
         <TimeInput
           placeholder='Time'
@@ -85,20 +124,24 @@ class DateTimeForm extends React.Component<any, any> {
           className='example-calendar-input'
           name='time'
           autoComplete='off'
+          clearable={clearable}
           value={this.state.time}
           iconPosition='left'
-          onChange={this.handleChange} />
+          onChange={this.handleChange}
+        />
         <br />
         <DateTimeInput
           placeholder='Date Time'
           className='example-calendar-input'
           popupPosition='bottom right'
           name='dateTime'
+          clearable={clearable}
           value={this.state.dateTime}
           iconPosition='left'
           preserveViewMode={false}
           autoComplete='off'
-          onChange={this.handleChange} />
+          onChange={this.handleChange}
+        />
         <br />
         <DatesRangeInput
           dateFormat='DD.MM.YY'
@@ -106,30 +149,36 @@ class DateTimeForm extends React.Component<any, any> {
           popupPosition='bottom right'
           className='example-calendar-input'
           name='datesRange'
+          clearable={clearable}
           value={this.state.datesRange}
           iconPosition='left'
           autoComplete='off'
-          onChange={this.handleChange} />
+          onChange={this.handleChange}
+        />
         <br />
         <YearInput
           placeholder='Year'
           className='example-calendar-input'
           name='year'
           popupPosition='bottom right'
+          clearable={clearable}
           value={this.state.year}
           iconPosition='left'
           autoComplete='off'
-          onChange={this.handleChange} />
+          onChange={this.handleChange}
+        />
         <br />
         <MonthInput
           placeholder='Month'
           className='example-calendar-input'
           name='month'
           popupPosition='bottom right'
+          clearable={clearable}
           value={this.state.month}
           iconPosition='left'
           autoComplete='off'
-          onChange={this.handleChange} />
+          onChange={this.handleChange}
+        />
       </Form>
     );
   }
@@ -163,42 +212,48 @@ class DateTimeFormInline extends React.Component<any, any> {
           className='example-calendar-input'
           value={this.state.date}
           name='date'
-          onChange={this.handleChange} />
+          onChange={this.handleChange}
+        />
         <br />
         <TimeInput
           inline
           className='example-calendar-input'
           value={this.state.time}
           name='time'
-          onChange={this.handleChange} />
+          onChange={this.handleChange}
+        />
         <br />
         <DateTimeInput
           inline
           className='example-calendar-input'
           value={this.state.dateTime}
           name='dateTime'
-          onChange={this.handleChange} />
+          onChange={this.handleChange}
+        />
         <br />
         <DatesRangeInput
           inline
           className='example-calendar-input'
           value={this.state.datesRange}
           name='datesRange'
-          onChange={this.handleChange} />
+          onChange={this.handleChange}
+        />
         <br />
         <YearInput
           inline
           className='example-calendar-input'
           value={this.state.year}
           name='year'
-          onChange={this.handleChange} />
+          onChange={this.handleChange}
+        />
         <br />
         <MonthInput
           inline
           className='example-calendar-input'
           value={this.state.month}
           name='month'
-          onChange={this.handleChange} />
+          onChange={this.handleChange}
+        />
       </Form>
     );
   }

--- a/src/inputs/DateInput.d.ts
+++ b/src/inputs/DateInput.d.ts
@@ -15,8 +15,25 @@ export interface DateInputProps {
     data: DateInputOnChangeData
   ) => void;
 
+  /**
+   * Called on clear.
+   *
+   * @param {SyntheticEvent} event - React's original SyntheticEvent.
+   * @param {object} data - All props and proposed value.
+   */
+  onClear?: (
+    event: React.SyntheticEvent<HTMLInputElement>,
+    data: DateInputOnChangeData
+  ) => void;
+
+  /** Using the clearable setting will let users remove their selection from a calendar. */
+  clearable?: boolean;
+
   /** Shorthand for Icon. */
   icon?: any;
+
+  /** Optional Icon to display inside the clearable Input. */  
+  clearIcon?: any;
 
   /** Position for the popup. */
   popupPosition?:

--- a/src/inputs/DateTimeInput.d.ts
+++ b/src/inputs/DateTimeInput.d.ts
@@ -15,8 +15,25 @@ export interface DateTimeInputProps {
     data: DateTimeInputOnChangeData
   ) => void;
 
+  /**
+   * Called on clear.
+   *
+   * @param {SyntheticEvent} event - React's original SyntheticEvent.
+   * @param {object} data - All props and proposed value.
+   */
+  onClear?: (
+    event: React.SyntheticEvent<HTMLInputElement>,
+    data: DateTimeInputOnChangeData
+  ) => void;
+
+  /** Using the clearable setting will let users remove their selection from a calendar. */
+  clearable?: boolean;
+
   /** Shorthand for Icon. */
   icon?: any;
+
+  /** Optional Icon to display inside the clearable Input. */  
+  clearIcon?: any;
 
   /** Position for the popup. */
   popupPosition?:

--- a/src/inputs/DatesRangeInput.d.ts
+++ b/src/inputs/DatesRangeInput.d.ts
@@ -15,8 +15,25 @@ export interface DatesRangeInputProps {
     data: DatesRangeInputOnChangeData
   ) => void;
 
+  /**
+   * Called on clear.
+   *
+   * @param {SyntheticEvent} event - React's original SyntheticEvent.
+   * @param {object} data - All props and proposed value.
+   */
+  onClear?: (
+    event: React.SyntheticEvent<HTMLInputElement>,
+    data: DatesRangeInputOnChangeData
+  ) => void;
+
+  /** Using the clearable setting will let users remove their selection from a calendar. */
+  clearable?: boolean;
+
   /** Shorthand for Icon. */
   icon?: any;
+  
+  /** Optional Icon to display inside the clearable Input. */  
+  clearIcon?: any;
 
   /** Position for the popup. */
   popupPosition?:

--- a/src/inputs/MonthInput.d.ts
+++ b/src/inputs/MonthInput.d.ts
@@ -15,8 +15,25 @@ export interface MonthInputProps {
     data: MonthInputOnChangeData
   ) => void;
 
+  /**
+   * Called on clear.
+   *
+   * @param {SyntheticEvent} event - React's original SyntheticEvent.
+   * @param {object} data - All props and proposed value.
+   */
+  onClear?: (
+    event: React.SyntheticEvent<HTMLInputElement>,
+    data: MonthInputOnChangeData
+  ) => void;
+
+  /** Using the clearable setting will let users remove their selection from a calendar. */
+  clearable?: boolean;
+
   /** Shorthand for Icon. */
   icon?: any;
+
+  /** Optional Icon to display inside the clearable Input. */  
+  clearIcon?: any;
 
   /** Position for the popup. */
   popupPosition?:

--- a/src/inputs/TimeInput.d.ts
+++ b/src/inputs/TimeInput.d.ts
@@ -14,8 +14,25 @@ export interface TimeInputProps {
     data: TimeInputOnChangeData
   ) => void;
 
+  /**
+   * Called on clear.
+   *
+   * @param {SyntheticEvent} event - React's original SyntheticEvent.
+   * @param {object} data - All props and proposed value.
+   */
+  onClear?: (
+    event: React.SyntheticEvent<HTMLInputElement>,
+    data: TimeInputOnChangeData
+  ) => void;
+
+  /** Using the clearable setting will let users remove their selection from a calendar. */
+  clearable?: boolean;
+
   /** Shorthand for Icon. */
   icon?: any;
+
+  /** Optional Icon to display inside the clearable Input. */  
+  clearIcon?: any;
 
   /** Position for the popup. */
   popupPosition?:

--- a/src/inputs/YearInput.d.ts
+++ b/src/inputs/YearInput.d.ts
@@ -14,8 +14,25 @@ export interface YearInputProps {
     data: YearInputOnChangeData
   ) => void;
 
+  /**
+   * Called on clear.
+   *
+   * @param {SyntheticEvent} event - React's original SyntheticEvent.
+   * @param {object} data - All props and proposed value.
+   */
+  onClear?: (
+    event: React.SyntheticEvent<HTMLInputElement>,
+    data: YearInputOnChangeData
+  ) => void;
+
+  /** Using the clearable setting will let users remove their selection from a calendar. */
+  clearable?: boolean;
+
   /** Shorthand for Icon. */
   icon?: any;
+
+  /** Optional Icon to display inside the clearable Input. */  
+  clearIcon?: any;
 
   /** Position for the popup. */
   popupPosition?:

--- a/src/lib/tick.js
+++ b/src/lib/tick.js
@@ -3,7 +3,7 @@
  * Sometimes we need to delay rerendering components
  * on one tick (if they are inside  `Popup` and rerendering could
  * change `Popup`'s content sizes).
- * Becouse it races with Popup's onclick handler.
+ * Because it races with Popup's onclick handler.
  * `Popup` relies on it's content sizes when computing
  * should popup stay open or be closed. So we need
  * to wait until `Popup`'s onclick handler done its job.

--- a/src/views/InputView.tsx
+++ b/src/views/InputView.tsx
@@ -46,7 +46,7 @@ interface InputViewProps {
   render: (props: any) => React.ReactNode[];
   /** Called after input field value has changed. */
   onChange: (e: React.SyntheticEvent, data: any) => void;
-  /** Called after remove icon has clicked. */
+  /** Called after clear icon has clicked. */
   onClear: (e: React.SyntheticEvent, data: any) => void;
   /** Picker. */
   children: React.ReactNode[];

--- a/src/views/InputView.tsx
+++ b/src/views/InputView.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { Form, FormInputProps, Popup } from 'semantic-ui-react';
+import * as _ from 'lodash';
+import { Icon, Form, FormInputProps, Popup, SemanticICONS } from 'semantic-ui-react';
 
 import { findHTMLElement } from '../lib';
 
@@ -10,8 +11,30 @@ const popupStyle = {
 
 class FormInputWithRef extends React.Component<FormInputProps, any> {
   public render() {
+    const inputProps = {
+      ...this.props,
+      clearable: undefined,
+      onClear: undefined,
+    };
+
+    let {
+      value,
+      clearable,
+      icon,
+      clearIcon,
+      onClear,
+    } = this.props;
+
+    clearIcon = _.isString(clearIcon) ?
+      <Icon name={clearIcon as SemanticICONS} link onClick={onClear} /> :
+      <clearIcon.type {...clearIcon.props} link onClick={onClear} />
+    ;
+
     return (
-      <Form.Input { ...this.props }/>
+      <Form.Input
+        {...inputProps}
+        icon={value && clearable ? clearIcon : icon}
+      />
     );
   }
 }
@@ -23,12 +46,20 @@ interface InputViewProps {
   render: (props: any) => React.ReactNode[];
   /** Called after input field value has changed. */
   onChange: (e: React.SyntheticEvent, data: any) => void;
+  /** Called after remove icon has clicked. */
+  onClear: (e: React.SyntheticEvent, data: any) => void;
   /** Picker. */
   children: React.ReactNode[];
   /** Whether to close a popup when cursor leaves it. */
   closeOnMouseLeave?: boolean;
   /** A field can have its label next to instead of above it. */
   inlineLabel?: boolean;
+  /** Using the clearable setting will let users remove their selection from a calendar. */
+  clearable?: boolean;
+  /** Optional Icon to display inside the Input. */
+  icon?: any;
+  /** Optional Icon to display inside the clearable Input. */  
+  clearIcon?: any;
   /** Whether popup is closed. */
   popupIsClosed?: boolean;
   /** The node where the picker should mount. */
@@ -56,6 +87,9 @@ class InputView extends React.Component<InputViewProps, any> {
     inline: false,
     closeOnMouseLeave: true,
     tabIndex: '0',
+    clearable: false,
+    icon: 'calendar',
+    clearIcon: 'remove',
   };
 
   private initialInputNode: HTMLElement | undefined;
@@ -93,6 +127,7 @@ class InputView extends React.Component<InputViewProps, any> {
       value,
       closeOnMouseLeave,
       onChange,
+      onClear,
       children,
       inlineLabel,
       popupIsClosed,
@@ -112,6 +147,7 @@ class InputView extends React.Component<InputViewProps, any> {
         value={value}
         tabIndex={tabIndex}
         inline={inlineLabel}
+        onClear={(e) => (onClear || onChange)(e, { ...rest, value: '' })}
         onChange={onChange} />
     );
 


### PR DESCRIPTION
Different properties are added to the inputs with the idea of being consistent with the Semantic UI API and allow another alternative to clean the selection in the calendars.

-  **onClear**, `{func}` Called after clear icon has clicked.
-  **clearable**, `{boolean}` Using the clearable setting will let users remove their selection from a calendar. It's set as `false` by default.
-  **clearIcon**, `{any}` Optional Icon to display inside the clearable Input. Set as 'remove' by default when clearable is `true`.

The names chosen for the added properties coincide with the similar properties in the `Select` present in the latest version of Semantic UI, thus allowing the programmer an intuitive idea of how they would be the same in the calendar.

* * *
In addition, the  examples are modified to interactively show the operation of the new properties, both with the default icon and with a customized one.

Regarding the decisions made for the design of the cleaning option, it is chosen that the icon will appear in place of the calendar icon when `clearable` is` true` and has a selected value. This design decision can be discussed and taken into account for future contributions.
