### PR TITLE
Mark dates of interest

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ moment.locale('ru');
 | ``pickerStyle`` | {object} Optional `style` object for picker. |
 | ``duration`` | {number} Optional duration of the CSS transition animation in milliseconds. Default: `200` |
 | ``animation`` | {string} Optional named animation event to used. Must be defined in CSS. Default: `'scale'` |
+| ``marked`` | {string\|moment\|Date\|string[]\|moment[]\|Date[]} Date or list of dates that are displayed as marked |
+| ``markColor`` | {string\|SemanticCOLORs} String specifying the mark color. Must be one of the Semantic UI colors |
 
 ### TimeInput
 

--- a/example/calendar.tsx
+++ b/example/calendar.tsx
@@ -226,6 +226,8 @@ class DateTimeFormInline extends React.Component<any, any> {
           value={this.state.date}
           name='date'
           onChange={this.handleChange}
+          marked={[new Date('February 5 2019'), new Date('February 8 2019')]}
+          markColor='orange'
         />
         <br />
         <TimeInput

--- a/src/inputs/DateInput.tsx
+++ b/src/inputs/DateInput.tsx
@@ -236,6 +236,8 @@ class DateInput extends BaseInput<DateInputProps, DateInputState> {
       maxDate,
       enable,
       inline,
+      marked,
+      markColor,
     } = this.props;
     const pickerProps = {
       isPickerInFocus: this.isPickerInFocus,
@@ -255,6 +257,7 @@ class DateInput extends BaseInput<DateInputProps, DateInputState> {
       maxDate: parseValue(maxDate, dateFormat),
     };
     const disableParsed = parseArrayOrValue(disable, dateFormat);
+    const markedParsed = parseArrayOrValue(marked, dateFormat)
     const { mode } = this.state;
     if (mode === 'year') {
       return (
@@ -274,7 +277,7 @@ class DateInput extends BaseInput<DateInputProps, DateInputState> {
       );
     }
 
-    return <DayPicker {...pickerProps} disable={disableParsed} />;
+    return <DayPicker {...pickerProps} disable={disableParsed} marked={markedParsed} markColor={markColor} />;
   }
 
   private switchToNextModeUndelayed = (): void => {

--- a/src/pickers/BasePicker.tsx
+++ b/src/pickers/BasePicker.tsx
@@ -10,6 +10,7 @@ import * as React from 'react';
 import {
   RangeIndexes,
 } from '../views/BaseCalendarView';
+import { SemanticCOLORS } from 'semantic-ui-react';
 
 interface HandleChangeParams {
   value?: string;
@@ -77,6 +78,16 @@ export interface MinMaxValueProps {
   minDate?: Moment;
   /** Maximal date that could be selected. */
   maxDate?: Moment;
+}
+
+export interface MarkedValuesProps {
+  /** Array of marked dates. */
+  marked?: Moment[];
+}
+
+export interface MarkColorValueProps {
+  /** String specifying the mark color (Optional). */
+  markColor?: SemanticCOLORS;
 }
 
 export interface TimePickerProps {
@@ -242,6 +253,7 @@ abstract class BasePicker<P extends BasePickerProps> extends React.Component<P, 
 
   /** Return position numbers of cells that should be displayed as disabled */
   protected abstract getDisabledPositions(): number[];
+  
 }
 
 export interface ProvideHeadingValue {

--- a/src/pickers/dayPicker/DayPicker.tsx
+++ b/src/pickers/dayPicker/DayPicker.tsx
@@ -9,12 +9,15 @@ import {
   DisableValuesProps,
   EnableValuesProps,
   MinMaxValueProps,
+  MarkedValuesProps,
+  MarkColorValueProps,
   ProvideHeadingValue,
   SingleSelectionPicker,
 } from '../BasePicker';
 import {
   buildDays,
   getDisabledDays,
+  getMarkedDays,
   getInitialDatePosition,
   isNextPageAvailable,
   isPrevPageAvailable,
@@ -34,7 +37,9 @@ export interface DayPickerOnChangeData extends BasePickerOnChangeData {
 type DayPickerProps = BasePickerProps
   & DisableValuesProps
   & EnableValuesProps
-  & MinMaxValueProps;
+  & MinMaxValueProps
+  & MarkedValuesProps
+  & MarkColorValueProps;
 
 class DayPicker
   extends SingleSelectionPicker<DayPickerProps>
@@ -58,6 +63,8 @@ class DayPicker
       enable,
       minDate,
       maxDate,
+      marked,
+      markColor,
       ...rest
     } = this.props;
 
@@ -77,7 +84,9 @@ class DayPicker
         onCellHover={this.onHoveredCellPositionChange}
         currentHeadingValue={this.getCurrentDate()}
         disabledItemIndexes={this.getDisabledPositions()}
-        activeItemIndex={this.getActiveCellPosition()} />
+        activeItemIndex={this.getActiveCellPosition()}
+        markedItemIndexes={this.getMarkedPositions()}
+        markColor={markColor} />
     );
   }
 
@@ -136,6 +145,20 @@ class DayPicker
     } = this.props;
 
     return getDisabledDays(disable, maxDate, minDate, this.state.date, DAYS_ON_PAGE, enable);
+  }
+
+  protected getMarkedPositions(): number[] {
+    /*
+      Return position numbers of dates that should be displayed as marked
+      (position in array returned by `this.buildCalendarValues`).
+    */
+    const {
+      marked,
+    } = this.props;
+
+    if (marked) {
+      return getMarkedDays(marked, this.state.date, DAYS_ON_PAGE)
+    } else return []
   }
 
   protected isNextPageAvailable = (): boolean => {

--- a/src/pickers/dayPicker/sharedFunctions.ts
+++ b/src/pickers/dayPicker/sharedFunctions.ts
@@ -98,6 +98,27 @@ export function getDisabledDays(
   return _.sortBy(_.uniq(disabledDays).filter((day) => !_.isNil(day)));
 }
 
+/** Return day positions that shoud be displayed as marked. */
+export function getMarkedDays(
+  marked: Moment[],
+  currentDate: Moment,
+  daysOnPage: number,): number[] {
+  const dayPositions = _.range(daysOnPage);
+  const daysInCurrentMonthPositions = getDefaultEnabledDayPositions(buildDays(currentDate, daysOnPage), currentDate);
+  let activeDays = dayPositions.filter((dayPosition) => !_.includes(daysInCurrentMonthPositions, dayPosition));
+  let markedDays = []
+
+  if (_.isArray(marked)) {
+    activeDays = _.concat(activeDays,
+                            marked
+                              .filter((date) => date.isSame(currentDate, 'month'))
+                              .map((date) => date.date())
+                              .map((date) => markedDays.push(daysInCurrentMonthPositions[date - 1]) ));
+  }
+
+  return _.sortBy(_.uniq(markedDays).filter((day) => !_.isNil(day)));
+}
+
 export function isNextPageAvailable(date: Moment, maxDate: Moment): boolean {
   if (_.isNil(maxDate)) {
     return true;

--- a/src/views/BaseCalendarView.ts
+++ b/src/views/BaseCalendarView.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { SemanticCOLORS } from 'semantic-ui-react';
 
 export interface BaseCalendarViewProps {
   /** Used for passing calendar dom element to parent component. */
@@ -17,6 +18,10 @@ export interface BaseCalendarViewProps {
   hoveredItemIndex?: number;
   /** An array of cell positions to display as disabled. */
   disabledItemIndexes?: number[];
+  /** An array of cell positions to display as marked. */
+  markedItemIndexes?: number[];
+  /** An array of cell positions to display as marked. */
+  markColor?: SemanticCOLORS;
 }
 
 export interface SingleSelectionCalendarViewProps {

--- a/src/views/CalendarBody/Body.tsx
+++ b/src/views/CalendarBody/Body.tsx
@@ -28,6 +28,10 @@ interface BodyProps {
   active?: number | number[];
   /** Array of element indexes in `data` array that should be displayed as disabled. */
   disabled?: number[];
+  /** Array of element indexes in `data` array that should be displayed as marked. */
+  marked?: number[];
+  /** The color of the mark that will be displayed on the calendar. */
+  markColor?: string;
 }
 
 function Body(props: BodyProps) {
@@ -39,6 +43,8 @@ function Body(props: BodyProps) {
     disabled,
     hovered,
     onCellHover,
+    marked,
+    markColor,
   } = props;
   const content = buildRows(data, width).map((row, rowIndex) => (
     <Table.Row key={`${rowIndex}${row[0]}`}>
@@ -48,6 +54,8 @@ function Body(props: BodyProps) {
           active={isActive(rowIndex, width, itemIndex, active)}
           hovered={isHovered(rowIndex, width, itemIndex, hovered)}
           disabled={isDisabled(rowIndex, width, itemIndex, disabled)}
+          marked={isMarked(rowIndex, width, itemIndex, marked)}
+          markColor={markColor}
           key={`${rowIndex * width + itemIndex}`}
           itemPosition={rowIndex * width + itemIndex}
           content={item}
@@ -130,6 +138,22 @@ function getCellStyle(width: BodyWidth): CellWidthStyle {
     default:
       break;
   }
+}
+
+function isMarked(rowIndex: number,
+                  rowWidth: number,
+                  colIndex: number,
+                  markedIndexes: number[]): boolean {
+  if (_.isNil(markedIndexes) || markedIndexes.length === 0) {
+    return false;
+  }
+  for (const markedIndex of markedIndexes) {
+    if (rowIndex * rowWidth + colIndex === markedIndex) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 export default Body;

--- a/src/views/CalendarBody/Cell.tsx
+++ b/src/views/CalendarBody/Cell.tsx
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 import * as React from 'react';
-import { Table } from 'semantic-ui-react';
+import { Table, Label } from 'semantic-ui-react';
 
 import { OnValueClickData } from '../BaseCalendarView';
 
@@ -42,6 +42,10 @@ interface CellProps {
   active?: boolean;
   /** Is cell disabled. */
   disabled?: boolean;
+  /** Is cell marked. */
+  marked?: boolean;
+  /** Color of the mark. */
+  markColor?: any;
 }
 
 class Cell extends React.Component<CellProps, any> {
@@ -53,6 +57,8 @@ class Cell extends React.Component<CellProps, any> {
       onClick,
       onHover,
       hovered,
+      marked,
+      markColor,
       ...rest
     } = this.props;
 
@@ -67,7 +73,7 @@ class Cell extends React.Component<CellProps, any> {
         style={cellStyle}
         onMouseOver={this.onCellHover}
         onClick={this.onCellClick}>
-        { content }
+        { (marked && !rest.disabled) ? <Label circular color={markColor} key={content}>{content}</Label> : content }
       </Table.Cell>
     );
   }

--- a/src/views/DayView.tsx
+++ b/src/views/DayView.tsx
@@ -38,6 +38,8 @@ class DayView extends BaseCalendarView<DayViewProps, any> {
       onCellHover,
       onMount,
       inline,
+      markedItemIndexes,
+      markColor,
       ...rest
     } = this.props;
 
@@ -59,7 +61,9 @@ class DayView extends BaseCalendarView<DayViewProps, any> {
           onCellHover={onCellHover}
           onCellClick={onValueClick}
           active={activeItemIndex}
-          disabled={disabledItemIndexes} />
+          disabled={disabledItemIndexes}
+          marked={markedItemIndexes}
+          markColor={markColor} />
       </Calendar>
     );
   }


### PR DESCRIPTION
This PR aims to give users the ability to mark dates of interest on the `DateInput`.

```
<DateInput
          inline
          className='example-calendar-input'
          value={this.state.date}
          name='date'
          onChange={this.handleChange}
          marked={[new Date('February 5 2019'), new Date('February 8 2019')]}
          markColor='orange'
/>
```

![image](https://user-images.githubusercontent.com/35106956/52284324-dcda1f80-296c-11e9-8891-7d00923dcf57.png)

>Code on! ᕦʕ •ᴥ•ʔᕤ