### PR TITLE
Implement MonthRangePicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,3 +293,25 @@ moment.locale('ru');
 | ``pickerStyle`` | {object} Optional `style` object for picker. |
 | ``duration`` | {number} Optional duration of the CSS transition animation in milliseconds. Default: `200` |
 | ``animation`` | {string} Optional named animation event to used. Must be defined in CSS. Default: `'scale'` |
+
+### MonthRangeInput
+
+| Prop | Description |
+| -----| ------------|
+| all that can be used with SUIR Form.Input | |
+| ``popupPosition``| {string} One of ['top left', 'top right', 'bottom left', 'bottom right', 'right center', 'left center', 'top center', 'bottom center']. Default: ``top left``|
+| ``inline`` | {bool} If ``true`` inline picker displayed. Default: ``false`` |
+| ``closable`` | {bool} If true, popup closes after selecting a month   |
+| ``inlineLabel`` | {bool} A field can have its label next to instead of above it. |
+| ``closeOnMouseLeave`` | {bool} Should close when cursor leaves calendar popup. Default: ``true`` |
+| ``dateFormat`` | {string} Moment date formatting string. Default: ``"MMM"`` |
+| ``maxDate`` | {string\|Moment\|Date\|string[]\|Moment[]\|Date[]} Maximum date that can be selected. |
+| ``minDate`` | {string\|Moment\|Date\|string[]\|Moment[]\|Date[]} Minimum date that can be selected. |
+| ``mountNode`` | {any} The node where the picker should mount. |
+| ``onClear`` | {func} Called after clear icon has clicked. |
+| ``clearable`` | {boolean} Using the clearable setting will let users remove their selection from a calendar. |
+| ``clearIcon`` | {any} Optional Icon to display inside the clearable Input. |
+| ``pickerWidth`` | {string} Optional width value for picker (any string value that could be assigned to `style.width`). |
+| ``pickerStyle`` | {object} Optional `style` object for picker. |
+| ``duration`` | {number} Optional duration of the CSS transition animation in milliseconds. Default: `200` |
+| ``animation`` | {string} Optional named animation event to used. Must be defined in CSS. Default: `'scale'` |

--- a/example/calendar.tsx
+++ b/example/calendar.tsx
@@ -196,6 +196,7 @@ class DateTimeForm extends React.Component<any, any> {
           autoComplete='off'
           onChange={this.handleChange}
         />
+        <br />
         <MonthRangeInput
           placeholder='MonthRange'
           dateFormat='YYYY-MM'

--- a/example/calendar.tsx
+++ b/example/calendar.tsx
@@ -17,6 +17,8 @@ import {
   DateTimeInputOnChangeData,
   MonthInput,
   MonthInputOnChangeData,
+  MonthRangeInput,
+  MonthRangeInputOnChangeData,
   TimeInput,
   TimeInputOnChangeData,
   YearInput,
@@ -29,6 +31,7 @@ type DateTimeFormHandleChangeData = DateInputOnChangeData
   | DatesRangeInputOnChangeData
   | DateTimeInputOnChangeData
   | MonthInputOnChangeData
+  | MonthRangeInputOnChangeData
   | TimeInputOnChangeData
   | YearInputOnChangeData;
 
@@ -82,6 +85,7 @@ class DateTimeForm extends React.Component<any, any> {
       dateTime: '',
       datesRange: '',
       month: '',
+      monthRange: '',
     };
   }
 
@@ -192,6 +196,17 @@ class DateTimeForm extends React.Component<any, any> {
           autoComplete='off'
           onChange={this.handleChange}
         />
+        <MonthRangeInput
+          placeholder='MonthRange'
+          dateFormat='YYYY-MM'
+          name='monthRange'
+          popupPosition='bottom right'
+          clearable={clearable}
+          closable
+          iconPosition='left'
+          autoComplete='off'
+          value={this.state.monthRange}
+          onChange={this.handleChange}/>
       </Form>
     );
   }
@@ -214,6 +229,7 @@ class DateTimeFormInline extends React.Component<any, any> {
       time: '',
       dateTime: '',
       datesRange: '',
+      monthRange: '',
     };
   }
 
@@ -265,6 +281,14 @@ class DateTimeFormInline extends React.Component<any, any> {
           className='example-calendar-input'
           value={this.state.month}
           name='month'
+          onChange={this.handleChange}
+        />
+        <br/>
+        <MonthRangeInput
+          inline
+          className='example-calendar-input'
+          value={this.state.monthRange}
+          name='monthRange'
           onChange={this.handleChange}
         />
       </Form>

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,3 +28,8 @@ export {
   MonthInputProps,
   MonthInputOnChangeData,
 } from './inputs/MonthInput';
+export {
+  default as MonthRangeInput,
+  MonthRangeInputProps,
+  MonthRangeInputOnChangeData,
+} from './inputs/MonthRangeInput';

--- a/src/inputs/DateInput.tsx
+++ b/src/inputs/DateInput.tsx
@@ -8,7 +8,7 @@ import {
   BasePickerOnChangeData,
 } from '../pickers/BasePicker';
 import DayPicker from '../pickers/dayPicker/DayPicker';
-import MonthPicker from '../pickers/MonthPicker';
+import MonthPicker from '../pickers/monthPicker/MonthPicker';
 import YearPicker from '../pickers/YearPicker';
 import InputView from '../views/InputView';
 import BaseInput, {

--- a/src/inputs/DateTimeInput.tsx
+++ b/src/inputs/DateTimeInput.tsx
@@ -8,7 +8,7 @@ import {
   BasePickerOnChangeData,
 } from '../pickers/BasePicker';
 import DayPicker from '../pickers/dayPicker/DayPicker';
-import MonthPicker from '../pickers/MonthPicker';
+import MonthPicker from '../pickers/monthPicker/MonthPicker';
 import HourPicker from '../pickers/timePicker/HourPicker';
 import MinutePicker from '../pickers/timePicker/MinutePicker';
 import YearPicker from '../pickers/YearPicker';

--- a/src/inputs/MonthInput.tsx
+++ b/src/inputs/MonthInput.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import CustomPropTypes from '../lib/CustomPropTypes';
 import MonthPicker, {
   MonthPickerOnChangeData,
-} from '../pickers/MonthPicker';
+} from '../pickers/monthPicker/MonthPicker';
 import InputView from '../views/InputView';
 import BaseInput, {
   BaseInputProps,

--- a/src/inputs/MonthRangeInput.tsx
+++ b/src/inputs/MonthRangeInput.tsx
@@ -1,45 +1,33 @@
 import * as _ from 'lodash';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
+import BaseInput, {BaseInputProps, BaseInputState, DateRelatedProps, MinMaxValueProps} from './BaseInput';
 
 import CustomPropTypes from '../lib/CustomPropTypes';
+import MonthRangePicker, {MonthRangePickerOnChangeData} from '../pickers/monthPicker/MonthRangePicker';
 import InputView from '../views/InputView';
+import {MonthInputProps} from './MonthInput';
 import {
   getInitializer,
   parseDatesRange,
   parseValue,
 } from './parse';
 
-import DatesRangePicker, {
-  DatesRangePickerOnChangeData,
-} from '../pickers/dayPicker/DatesRangePicker';
-import BaseInput, {
-  BaseInputProps,
-  BaseInputState,
-  DateRelatedProps,
-  MinMaxValueProps,
-} from './BaseInput';
-
 const DATES_SEPARATOR = ' - ';
 
-export type DatesRangeInputProps =
+export type MonthRangeInputProps =
   & BaseInputProps
   & DateRelatedProps
   & MinMaxValueProps;
 
-export interface DatesRangeInputOnChangeData extends DatesRangeInputProps {
+export interface MonthRangeInputOnChangeData extends MonthInputProps {
   value: string;
+  date: MonthRangePickerOnChangeData;
 }
 
-class DatesRangeInput extends BaseInput<DatesRangeInputProps, BaseInputState> {
-  /**
-   * Component responsibility:
-   *  - parse input value (start: Moment, end: Moment)
-   *  - handle DayPicker change (format {start: Moment, end: Moment} into
-   *    string 'start - end')
-   */
+class MonthRangeInput extends BaseInput<MonthRangeInputProps, BaseInputState> {
   public static readonly defaultProps = {
-    dateFormat: 'DD-MM-YYYY',
+    dateFormat: 'MM-YYYY',
     icon: 'calendar',
     inline: false,
   };
@@ -120,7 +108,7 @@ class DatesRangeInput extends BaseInput<DatesRangeInputProps, BaseInputState> {
         closePopup={this.closePopup}
         openPopup={this.openPopup}
         render={(pickerProps) =>
-          (<DatesRangePicker
+          (<MonthRangePicker
             {...pickerProps}
             isPickerInFocus={this.isPickerInFocus}
             isTriggerInFocus={this.isTriggerInFocus}
@@ -129,19 +117,19 @@ class DatesRangeInput extends BaseInput<DatesRangeInputProps, BaseInputState> {
             closePopup={this.closePopup}
             onChange={this.handleSelect}
             dateFormat={dateFormat}
-            initializeWith={getInitializer({ initialDate, dateFormat })}
+            initializeWith={getInitializer({initialDate, dateFormat})}
             start={start}
             end={end}
             minDate={parseValue(minDate, dateFormat)}
-            maxDate={parseValue(maxDate, dateFormat)} />)
+            maxDate={parseValue(maxDate, dateFormat)}/>)
         }
       />
     );
   }
 
   private handleSelect = (e: React.SyntheticEvent<HTMLElement>,
-                          { value }: DatesRangePickerOnChangeData) => {
-    const { dateFormat } = this.props;
+                          {value}: MonthRangePickerOnChangeData) => {
+    const {dateFormat} = this.props;
     const {
       start,
       end,
@@ -152,11 +140,12 @@ class DatesRangeInput extends BaseInput<DatesRangeInputProps, BaseInputState> {
     } else if (start) {
       outputString = `${start.format(dateFormat)}${DATES_SEPARATOR}`;
     }
-    _.invoke(this.props, 'onChange', e, { ...this.props, value: outputString });
+
+    _.invoke(this.props, 'onChange', e, {...this.props, value: outputString, date: value});
     if (this.props.closable && start && end) {
       this.closePopup();
     }
   }
 }
 
-export default DatesRangeInput;
+export default MonthRangeInput;

--- a/src/inputs/index.ts
+++ b/src/inputs/index.ts
@@ -28,3 +28,8 @@ export {
   MonthInputProps,
   MonthInputOnChangeData,
 } from './MonthInput';
+export {
+  default as MonthRangeInput,
+  MonthRangeInputProps,
+  MonthRangeInputOnChangeData,
+} from './MonthRangeInput';

--- a/src/inputs/parse.ts
+++ b/src/inputs/parse.ts
@@ -108,3 +108,46 @@ export function dateValueToString(value: DateValue, dateFormat: string): string 
 
   return moment(value, dateFormat).format(dateFormat);
 }
+
+function cleanDate(inputString: string, dateFormat: string): string {
+  const formattedDateLength = moment().format(dateFormat).length;
+
+  return inputString.trim().slice(0, formattedDateLength);
+}
+
+interface Range {
+  start?: moment.Moment;
+  end?: moment.Moment;
+}
+
+/**
+ * Extract start and end dates from input string.
+ * Return { start: Moment|undefined, end: Moment|undefined }
+ * @param {string} inputString Row input string from user
+ * @param {string} dateFormat Moment formatting string
+ * @param {string} inputSeparator Separator for split inputString
+ */
+export function parseDatesRange(
+  inputString: string = '',
+  dateFormat: string = '',
+  inputSeparator: string = ' - ',
+): Range {
+  const dates = inputString.split(inputSeparator)
+    .map((date) => cleanDate(date, dateFormat));
+  const result: Range = {};
+  let start;
+  let end;
+
+  start = moment(dates[0], dateFormat);
+  if (dates.length === 2) {
+    end = moment(dates[1], dateFormat);
+  }
+  if (start && start.isValid()) {
+    result.start = start;
+  }
+  if (end && end.isValid()) {
+    result.end = end;
+  }
+
+  return result;
+}

--- a/src/pickers/monthPicker/MonthPicker.tsx
+++ b/src/pickers/monthPicker/MonthPicker.tsx
@@ -1,8 +1,7 @@
 import * as _ from 'lodash';
-import * as moment from 'moment';
 import * as React from 'react';
 
-import MonthView from '../views/MonthView';
+import MonthView from '../../views/MonthView';
 import {
   BasePickerOnChangeData,
   BasePickerProps,
@@ -12,10 +11,17 @@ import {
   OptionalHeaderProps,
   ProvideHeadingValue,
   SingleSelectionPicker,
-} from './BasePicker';
+} from '../BasePicker';
+import {
+  buildCalendarValues,
+  getDisabledPositions,
+  getInitialDatePosition,
+  isNextPageAvailable,
+  isPrevPageAvailable,
+} from './sharedFunctions';
 
-const MONTHS_IN_YEAR = 12;
-const PAGE_WIDTH = 3;
+export const MONTHS_IN_YEAR = 12;
+export const PAGE_WIDTH = 3;
 
 type MonthPickerProps = BasePickerProps
   & DisableValuesProps
@@ -86,11 +92,7 @@ class MonthPicker
   }
 
   protected buildCalendarValues(): string[] {
-    /*
-      Return array of months (strings) like ['Aug', 'Sep', ...]
-      that used to populate calendar's page.
-    */
-    return moment.monthsShort();
+    return buildCalendarValues();
   }
 
   protected getSelectableCellPositions(): number[] {
@@ -102,11 +104,8 @@ class MonthPicker
 
   protected getInitialDatePosition(): number {
     const selectable = this.getSelectableCellPositions();
-    if (selectable.indexOf(this.state.date.month()) < 0) {
-      return selectable[0];
-    }
 
-    return this.state.date.month();
+    return getInitialDatePosition(selectable, this.state.date);
   }
 
   protected getActiveCellPosition(): number {
@@ -122,43 +121,14 @@ class MonthPicker
   }
 
   protected getDisabledPositions(): number[] {
-    /*
-      Return position numbers of months that should be displayed as disabled
-      (position in array returned by `this.buildCalendarValues`).
-    */
-    let disabled = [];
-    if (_.isArray(this.props.enable)) {
-      const enabledMonthPositions = this.props.enable
-        .filter((monthMoment) => monthMoment.isSame(this.state.date, 'year'))
-        .map((monthMoment) => monthMoment.month());
-      disabled = disabled.concat(_.range(0, MONTHS_IN_YEAR)
-        .filter((monthPosition) => !_.includes(enabledMonthPositions, monthPosition)));
-    }
-    if (_.isArray(this.props.disable)) {
-      disabled = disabled.concat(this.props.disable
-        .filter((monthMoment) => monthMoment.year() === this.state.date.year())
-        .map((monthMoment) => monthMoment.month()));
-    }
-    if (!_.isNil(this.props.maxDate)) {
-      if (this.props.maxDate.year() === this.state.date.year()) {
-        disabled = disabled.concat(
-          _.range(this.props.maxDate.month() + 1, MONTHS_IN_YEAR));
-      }
-      if (this.props.maxDate.year() < this.state.date.year()) {
-        disabled = _.range(0, MONTHS_IN_YEAR);
-      }
-    }
-    if (!_.isNil(this.props.minDate)) {
-      if (this.props.minDate.year() === this.state.date.year()) {
-        disabled = disabled.concat(_.range(0, this.props.minDate.month()));
-      }
-      if (this.props.minDate.year() > this.state.date.year()) {
-        disabled = _.range(0, MONTHS_IN_YEAR);
-      }
-    }
-    if (disabled.length > 0) {
-      return _.uniq(disabled);
-    }
+    const {
+      maxDate,
+      minDate,
+      enable,
+      disable,
+    } = this.props;
+
+    return getDisabledPositions(enable, disable, maxDate, minDate, this.state.date);
   }
 
   protected isNextPageAvailable(): boolean {
@@ -166,17 +136,8 @@ class MonthPicker
       maxDate,
       enable,
     } = this.props;
-    if (_.isArray(enable)) {
-      return _.some(enable, (enabledMonth) => enabledMonth.isAfter(this.state.date, 'year'));
-    }
-    if (_.isNil(maxDate)) {
-      return true;
-    }
-    if (this.state.date.year() >= maxDate.year()) {
-      return false;
-    }
 
-    return true;
+    return isNextPageAvailable(maxDate, enable, this.state.date);
   }
 
   protected isPrevPageAvailable(): boolean {
@@ -184,17 +145,8 @@ class MonthPicker
       minDate,
       enable,
     } = this.props;
-    if (_.isArray(enable)) {
-      return _.some(enable, (enabledMonth) => enabledMonth.isBefore(this.state.date, 'year'));
-    }
-    if (_.isNil(minDate)) {
-      return true;
-    }
-    if (this.state.date.year() <= minDate.year()) {
-      return false;
-    }
 
-    return true;
+    return isPrevPageAvailable(minDate, enable, this.state.date);
   }
 
   protected handleChange = (e: React.SyntheticEvent<HTMLElement>, { value }): void => {

--- a/src/pickers/monthPicker/MonthPicker.tsx
+++ b/src/pickers/monthPicker/MonthPicker.tsx
@@ -13,15 +13,16 @@ import {
   SingleSelectionPicker,
 } from '../BasePicker';
 import {
+  MONTH_PAGE_WIDTH,
+  MONTHS_IN_YEAR,
+} from './const';
+import {
   buildCalendarValues,
   getDisabledPositions,
   getInitialDatePosition,
   isNextPageAvailable,
   isPrevPageAvailable,
 } from './sharedFunctions';
-
-export const MONTHS_IN_YEAR = 12;
-export const PAGE_WIDTH = 3;
 
 type MonthPickerProps = BasePickerProps
   & DisableValuesProps
@@ -46,7 +47,7 @@ class MonthPicker
   */
   constructor(props) {
     super(props);
-    this.PAGE_WIDTH = PAGE_WIDTH;
+    this.PAGE_WIDTH = MONTH_PAGE_WIDTH;
   }
 
   public render() {

--- a/src/pickers/monthPicker/MonthRangePicker.tsx
+++ b/src/pickers/monthPicker/MonthRangePicker.tsx
@@ -12,7 +12,10 @@ import {
   ProvideHeadingValue,
   RangeSelectionPicker,
 } from '../BasePicker';
-import {MONTHS_IN_YEAR, PAGE_WIDTH} from './MonthPicker';
+import {
+  MONTH_PAGE_WIDTH,
+  MONTHS_IN_YEAR,
+} from './const';
 import {
   buildCalendarValues,
   getDisabledPositions,
@@ -37,7 +40,7 @@ class MonthRangePicker
   implements ProvideHeadingValue {
   constructor(props) {
     super(props);
-    this.PAGE_WIDTH = PAGE_WIDTH;
+    this.PAGE_WIDTH = MONTH_PAGE_WIDTH;
   }
 
   public render() {

--- a/src/pickers/monthPicker/MonthRangePicker.tsx
+++ b/src/pickers/monthPicker/MonthRangePicker.tsx
@@ -1,0 +1,215 @@
+import * as _ from 'lodash';
+import {Moment} from 'moment';
+import * as moment from 'moment';
+import * as React from 'react';
+
+import {RangeIndexes} from '../../views/BaseCalendarView';
+import MonthRangeView from '../../views/MonthRangeView';
+import {
+  BasePickerOnChangeData,
+  BasePickerProps,
+  MinMaxValueProps,
+  ProvideHeadingValue,
+  RangeSelectionPicker,
+} from '../BasePicker';
+import {MONTHS_IN_YEAR, PAGE_WIDTH} from './MonthPicker';
+import {
+  buildCalendarValues,
+  getDisabledPositions,
+  getInitialDatePosition,
+  isNextPageAvailable,
+  isPrevPageAvailable,
+} from './sharedFunctions';
+
+interface MonthRangePickerProps extends BasePickerProps, MinMaxValueProps {
+  /** Moment date formatting string. */
+  dateFormat: string;
+  /** Start of currently selected dates range. */
+  start: Moment;
+  /** End of currently selected dates range. */
+  end: Moment;
+}
+
+export type MonthRangePickerOnChangeData = BasePickerOnChangeData;
+
+class MonthRangePicker
+  extends RangeSelectionPicker<MonthRangePickerProps>
+  implements ProvideHeadingValue {
+  constructor(props) {
+    super(props);
+    this.PAGE_WIDTH = PAGE_WIDTH;
+  }
+
+  public render() {
+    const {
+      onChange,
+      value,
+      initializeWith,
+      closePopup,
+      inline,
+      isPickerInFocus,
+      isTriggerInFocus,
+      onCalendarViewMount,
+      dateFormat,
+      start,
+      end,
+      minDate,
+      maxDate,
+      ...rest
+    } = this.props;
+
+    return (
+      <MonthRangeView
+        {...rest}
+        values={buildCalendarValues()}
+        onNextPageBtnClick={this.switchToNextPage}
+        onPrevPageBtnClick={this.switchToPrevPage}
+        onCellHover={this.onHoveredCellPositionChange}
+        hoveredItemIndex={this.state.hoveredCellPosition}
+        onValueClick={this.handleChange}
+        inline={this.props.inline}
+        hasPrevPage={this.isPrevPageAvailable()}
+        hasNextPage={this.isNextPageAvailable()}
+        onBlur={this.handleBlur}
+        onMount={this.props.onCalendarViewMount}
+        currentHeadingValue={this.getCurrentDate()}
+        currentRangeHeadingValue={this.getSelectedRange()}
+        activeRange={this.getActiveCellsPositions()}
+        disabledItemIndexes={this.getDisabledPositions()}/>
+    );
+  }
+
+  public getCurrentDate(): string {
+    /* Return currently selected year and month(string) to display in calendar header. */
+    return this.state.date.format('YYYY');
+  }
+
+  protected buildCalendarValues(): string[] {
+    return buildCalendarValues();
+  }
+
+  protected getSelectableCellPositions(): number[] {
+    return _.filter(
+      _.range(0, MONTHS_IN_YEAR),
+      (d) => !_.includes(this.getDisabledPositions(), d),
+    );
+  }
+
+  protected getActiveCellsPositions(): RangeIndexes {
+    /*
+      Return starting and ending positions of month range that should be displayed as active
+      { start: number, end: number }
+    */
+    const {
+      start,
+      end,
+    } = this.props;
+    const currentYear = this.state.date.year();
+    const result = {
+      start: undefined,
+      end: undefined,
+    };
+
+    if (start && end) {
+      if (currentYear < start.year() || currentYear > end.year()) {
+        return result;
+      }
+
+      result.start = currentYear === start.year() ? start.month() : 0;
+      result.end = currentYear === end.year() ? end.month() : MONTHS_IN_YEAR - 1;
+    }
+    if (start && !end) {
+      result.start = currentYear === start.year() ? start.month() : undefined;
+    }
+
+    return result;
+  }
+
+  protected getDisabledPositions(): number[] {
+    /*
+      Return position numbers of dates that should be displayed as disabled
+      (position in array returned by `this.buildCalendarValues`).
+    */
+    const {
+      maxDate,
+      minDate,
+    } = this.props;
+
+    return getDisabledPositions(undefined, undefined, maxDate, minDate, this.state.date);
+  }
+
+  protected isNextPageAvailable(): boolean {
+    const {maxDate} = this.props;
+
+    return isNextPageAvailable(maxDate, undefined, this.state.date);
+  }
+
+  protected isPrevPageAvailable(): boolean {
+    const {minDate} = this.props;
+
+    return isPrevPageAvailable(minDate, undefined, this.state.date);
+  }
+
+  protected getSelectedRange(): string {
+    /* Return currently selected dates range(string) to display in calendar header. */
+    const {
+      start,
+      end,
+      dateFormat,
+    } = this.props;
+
+    return `${start ? start.format(dateFormat) : '- - -'} - ${end ? end.format(dateFormat) : '- - -'}`;
+  }
+
+  protected handleChange = (e: React.SyntheticEvent<HTMLElement>, {itemPosition}) => {
+    // call `onChange` with value: { start: moment, end: moment }
+    const {
+      start,
+      end,
+    } = this.props;
+    const data: MonthRangePickerOnChangeData = {
+      ...this.props,
+      value: {},
+    };
+    if (_.isNil(start) && _.isNil(end)) {
+      data.value = {start: moment({year: this.state.date.year(), month: itemPosition, date: 1})};
+    } else if (!_.isNil(start) && _.isNil(end)) {
+      data.value = {
+        start,
+        end: moment({year: this.state.date.year(), month: itemPosition, date: 1}).endOf('month'),
+      };
+    }
+
+    this.props.onChange(e, data);
+  }
+
+  protected switchToNextPage = (e: React.SyntheticEvent<HTMLElement>,
+                                data: any,
+                                callback: () => void): void => {
+    this.setState(({date}) => {
+      const nextDate = date.clone();
+      nextDate.add(1, 'year');
+
+      return {date: nextDate};
+    }, callback);
+  }
+
+  protected switchToPrevPage = (e: React.SyntheticEvent<HTMLElement>,
+                                data: any,
+                                callback: () => void): void => {
+    this.setState(({date}) => {
+      const prevDate = date.clone();
+      prevDate.subtract(1, 'year');
+
+      return {date: prevDate};
+    }, callback);
+  }
+
+  protected getInitialDatePosition = (): number => {
+    const selectable = this.getSelectableCellPositions();
+
+    return getInitialDatePosition(selectable, this.state.date);
+  }
+}
+
+export default MonthRangePicker;

--- a/src/pickers/monthPicker/const.ts
+++ b/src/pickers/monthPicker/const.ts
@@ -1,0 +1,4 @@
+
+export const MONTHS_IN_YEAR = 12;
+/** How much months to place in row on calendar page. */
+export const MONTH_PAGE_WIDTH = 3;

--- a/src/pickers/monthPicker/sharedFunctions.ts
+++ b/src/pickers/monthPicker/sharedFunctions.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 import * as moment from 'moment';
-import {MONTHS_IN_YEAR} from './MonthPicker';
+import { MONTHS_IN_YEAR } from './const';
 
 const buildCalendarValues = (): string[] => {
   /*

--- a/src/pickers/monthPicker/sharedFunctions.ts
+++ b/src/pickers/monthPicker/sharedFunctions.ts
@@ -1,0 +1,106 @@
+import * as _ from 'lodash';
+import * as moment from 'moment';
+import {MONTHS_IN_YEAR} from './MonthPicker';
+
+const buildCalendarValues = (): string[] => {
+  /*
+    Return array of months (strings) like ['Aug', 'Sep', ...]
+    that used to populate calendar's page.
+  */
+  return moment.monthsShort();
+};
+
+const getInitialDatePosition = (
+  selectable: number[],
+  currentDate: moment.Moment,
+): number => {
+  if (selectable.indexOf(currentDate.month()) < 0) {
+    return selectable[0];
+  }
+
+  return currentDate.month();
+};
+
+const getDisabledPositions = (
+  enable: moment.Moment[],
+  disable: moment.Moment[],
+  maxDate: moment.Moment,
+  minDate: moment.Moment,
+  currentDate: moment.Moment,
+): number[] => {
+  /*
+    Return position numbers of months that should be displayed as disabled
+    (position in array returned by `this.buildCalendarValues`).
+  */
+  let disabled = [];
+  if (_.isArray(enable)) {
+    const enabledMonthPositions = enable
+      .filter((monthMoment) => monthMoment.isSame(currentDate, 'year'))
+      .map((monthMoment) => monthMoment.month());
+    disabled = disabled.concat(_.range(0, MONTHS_IN_YEAR)
+      .filter((monthPosition) => !_.includes(enabledMonthPositions, monthPosition)));
+  }
+  if (_.isArray(disable)) {
+    disabled = disabled.concat(disable
+      .filter((monthMoment) => monthMoment.year() === currentDate.year())
+      .map((monthMoment) => monthMoment.month()));
+  }
+  if (!_.isNil(maxDate)) {
+    if (maxDate.year() === currentDate.year()) {
+      disabled = disabled.concat(
+        _.range(maxDate.month() + 1, MONTHS_IN_YEAR));
+    }
+    if (maxDate.year() < currentDate.year()) {
+      disabled = _.range(0, MONTHS_IN_YEAR);
+    }
+  }
+  if (!_.isNil(minDate)) {
+    if (minDate.year() === currentDate.year()) {
+      disabled = disabled.concat(_.range(0, minDate.month()));
+    }
+    if (minDate.year() > currentDate.year()) {
+      disabled = _.range(0, MONTHS_IN_YEAR);
+    }
+  }
+  if (disabled.length > 0) {
+    return _.uniq(disabled);
+  }
+};
+
+const isNextPageAvailable = (
+  maxDate: moment.Moment,
+  enable: moment.Moment[],
+  currentDate: moment.Moment,
+): boolean => {
+  if (_.isArray(enable)) {
+    return _.some(enable, (enabledMonth) => enabledMonth.isAfter(currentDate, 'year'));
+  }
+  if (_.isNil(maxDate)) {
+    return true;
+  }
+
+  return currentDate.year() < maxDate.year();
+};
+
+const isPrevPageAvailable = (
+  minDate: moment.Moment,
+  enable: moment.Moment[],
+  currentDate: moment.Moment,
+): boolean => {
+  if (_.isArray(enable)) {
+    return _.some(enable, (enabledMonth) => enabledMonth.isBefore(currentDate, 'year'));
+  }
+  if (_.isNil(minDate)) {
+    return true;
+  }
+
+  return currentDate.year() > minDate.year();
+};
+
+export {
+  buildCalendarValues,
+  getInitialDatePosition,
+  getDisabledPositions,
+  isNextPageAvailable,
+  isPrevPageAvailable,
+};

--- a/src/views/MonthRangeView.tsx
+++ b/src/views/MonthRangeView.tsx
@@ -13,7 +13,7 @@ import Calendar from './Calendar';
 import Body from './CalendarBody/Body';
 import Header from './CalendarHeader/Header';
 
-import {MONTH_CALENDAR_ROW_WIDTH} from './MonthView';
+import { MONTH_CALENDAR_ROW_WIDTH } from './MonthView';
 
 type MonthRangeViewProps =
   BaseCalendarViewProps

--- a/src/views/MonthRangeView.tsx
+++ b/src/views/MonthRangeView.tsx
@@ -1,0 +1,95 @@
+import * as _ from 'lodash';
+import * as React from 'react';
+import {findHTMLElement} from '../lib';
+
+import BaseCalendarView, {
+  BaseCalendarViewProps,
+  CalendarWithHeaderViewProps,
+  HeadingValueProps,
+  RangeSelectionCalendarViewProps,
+} from './BaseCalendarView';
+
+import Calendar from './Calendar';
+import Body from './CalendarBody/Body';
+import Header from './CalendarHeader/Header';
+
+import {MONTH_CALENDAR_ROW_WIDTH} from './MonthView';
+
+type MonthRangeViewProps =
+  BaseCalendarViewProps
+  & HeadingValueProps
+  & RangeSelectionCalendarViewProps
+  & CalendarWithHeaderViewProps;
+
+const MONTH_POSITIONS = _.range(12);
+
+function getActive(start: number, end: number): number | number[] | undefined {
+  if (_.isNil(start) && _.isNil(end)) {
+    return;
+  }
+  if (!_.isNil(start) && _.isNil(end)) {
+    return start;
+  }
+  if (!_.isNil(start) && !_.isNil(end)) {
+    return MONTH_POSITIONS.slice(start, end + 1);
+  }
+}
+
+class MonthRangeView extends BaseCalendarView<MonthRangeViewProps, any> {
+  public static defaultProps = {
+    active: {
+      start: undefined,
+      end: undefined,
+    },
+  };
+
+  public render() {
+    const {
+      values,
+      onNextPageBtnClick,
+      onPrevPageBtnClick,
+      onValueClick,
+      hasPrevPage,
+      hasNextPage,
+      currentHeadingValue,
+      onHeaderClick,
+      activeRange,
+      disabledItemIndexes,
+      currentRangeHeadingValue,
+      hoveredItemIndex,
+      onCellHover,
+      onMount,
+      inline,
+      ...rest
+    } = this.props;
+    const {
+      start,
+      end,
+    } = activeRange;
+
+    return (
+      <Calendar ref={(e) => this.calendarNode = findHTMLElement(e)} outlineOnFocus={inline} {...rest}>
+        <Header
+          width={MONTH_CALENDAR_ROW_WIDTH}
+          displayWeeks={false}
+          rangeRowContent={currentRangeHeadingValue}
+          onNextPageBtnClick={onNextPageBtnClick}
+          onPrevPageBtnClick={onPrevPageBtnClick}
+          hasNextPage={hasNextPage}
+          hasPrevPage={hasPrevPage}
+          title={currentHeadingValue}
+          onHeaderClick={onHeaderClick}/>
+        <Body
+          width={MONTH_CALENDAR_ROW_WIDTH}
+          data={values}
+          onCellClick={onValueClick}
+          onCellHover={onCellHover}
+          hovered={hoveredItemIndex}
+          active={getActive(start, end)}
+          disabled={disabledItemIndexes}/>
+      </Calendar>
+    );
+  }
+}
+
+export default MonthRangeView;

--- a/src/views/MonthView.tsx
+++ b/src/views/MonthView.tsx
@@ -11,7 +11,7 @@ import Header, { HeaderProps } from './CalendarHeader/Header';
 
 import { findHTMLElement } from '../lib';
 
-const MONTH_CALENDAR_ROW_WIDTH = 3;
+export const MONTH_CALENDAR_ROW_WIDTH = 3;
 
 type MonthViewProps =
   BaseCalendarViewProps

--- a/test/inputs/testMonthRangeInput.js
+++ b/test/inputs/testMonthRangeInput.js
@@ -1,0 +1,47 @@
+import {assert} from "chai";
+import * as Enzyme from "enzyme";
+import * as Adapter from "enzyme-adapter-react-16";
+import {
+  mount
+} from "enzyme";
+import * as moment from "moment";
+import * as sinon from "sinon";
+import * as React from "react";
+import * as _ from "lodash";
+import MonthRangeInput from "../../src/inputs/MonthRangeInput";
+
+Enzyme.configure({adapter: new Adapter()});
+
+describe("<MonthRangeInput />: handleSelect_from", () => {
+  it("call `onChange`", () => {
+    const onChangeFake = sinon.fake();
+    const wrapper = mount(<MonthRangeInput onChange={onChangeFake}/>);
+    const currentDate = new Date();
+    const currentYear = currentDate.getFullYear();
+
+    wrapper.instance().handleSelect("click", {value: {start: moment().set("month", 2)}});
+    const firstCalledWithArgs = onChangeFake.args[0];
+
+    assert(onChangeFake.calledOnce, "`onChange` callback called once");
+    assert.equal(firstCalledWithArgs[0], "click", "correct first argument");
+    assert(_.isString(firstCalledWithArgs[1].value), "value is string");
+    assert.equal(firstCalledWithArgs[1].value, `03-${currentYear} - `, "correct value");
+  });
+});
+
+describe("<MonthRangeInput />: handleSelect_from_to", ()=>{
+  it("call `onChange`", () => {
+    const onChangeFake = sinon.fake();
+    const wrapper = mount(<MonthRangeInput onChange={onChangeFake}/>);
+    const currentDate = new Date();
+    const currentYear = currentDate.getFullYear();
+
+    wrapper.instance().handleSelect("click", {value: {start: moment().set("month", 2), end: moment().set("month", 5)}});
+    const secondCalledWithArgs = onChangeFake.args[0];
+
+    assert(onChangeFake.calledOnce, "`onChange` callback called twice");
+    assert.equal(secondCalledWithArgs[0], "click", "correct first argument");
+    assert(_.isString(secondCalledWithArgs[1].value), "value is string");
+    assert.equal(secondCalledWithArgs[1].value, `03-${currentYear} - 06-${currentYear}`, "correct value");
+  });
+});

--- a/test/pickers/testMonthPicker.js
+++ b/test/pickers/testMonthPicker.js
@@ -9,7 +9,7 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import * as moment from 'moment';
 
-import MonthPicker from '../../src/pickers/MonthPicker';
+import MonthPicker from '../../src/pickers/monthPicker/MonthPicker';
 
 Enzyme.configure({ adapter: new Adapter() });
 

--- a/test/pickers/testMonthRangePicker.js
+++ b/test/pickers/testMonthRangePicker.js
@@ -1,0 +1,258 @@
+import { assert } from 'chai';
+import * as Enzyme from 'enzyme';
+import * as Adapter from 'enzyme-adapter-react-16';
+import {
+  mount,
+} from 'enzyme';
+import * as sinon from 'sinon';
+import * as React from 'react';
+import * as _ from 'lodash';
+import * as moment from 'moment';
+
+import MonthRangePicker from '../../src/pickers/monthPicker/MonthRangePicker';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('<MonthRangePicker />', () => {
+  it('initialized with moment', () => {
+    const date = moment('2015-05-01');
+    const wrapper = mount(<MonthRangePicker initializeWith={date} />);
+    assert(moment.isMoment(wrapper.state('date')), 'has moment instance in `date` state field');
+    assert(wrapper.state('date').isSame(date), 'initialize `date` state field with moment provided in `initializeWith` prop');
+  });
+});
+
+describe('<MonthRangePicker />: buildCalendarValues', () => {
+  const date = moment('2015-05-01');
+  /* current year 2015 */
+  it('return array of strings', () => {
+    const wrapper = mount(<MonthRangePicker initializeWith={date} />);
+    assert(_.isArray(wrapper.instance().buildCalendarValues()), 'return array');
+    wrapper.instance().buildCalendarValues().forEach((month) => {
+      assert(_.isString(month), 'contains strings');
+    });
+  });
+});
+
+describe('<MonthRangePicker />: getActiveCellPosition', () => {
+  const date = moment('2015-05-01');
+  /* current year 2015 */
+  it('return index of start month', () => {
+    const wrapper = mount(<MonthRangePicker
+      value='03-2015 - '
+      start={moment({year: '2015', month: '03'})}
+      initializeWith={date} />);
+    const rangeIndexes = wrapper.instance().getActiveCellsPositions();
+    assert(_.isNumber(rangeIndexes.start), 'return number of start');
+    assert.equal(rangeIndexes.start, 3, 'return index 2 (means March)');
+    assert(_.isNil(rangeIndexes.end), 'return undefined of end');
+  });
+
+  it('return undefined if year of `value` does not equal to year of `date`', () => {
+    const wrapper = mount(<MonthRangePicker
+      value='02-2020 - '
+      start={moment({year: '2020', month: '02'})}
+      initializeWith={date} />);
+    const rangeIndexes = wrapper.instance().getActiveCellsPositions();
+    assert(_.isUndefined(rangeIndexes.start), 'return undefined');
+    assert(_.isNil(rangeIndexes.end), 'return undefined of end');
+  });
+
+  it('return indexes of start and end month', () => {
+    const wrapper = mount(<MonthRangePicker
+      value={'03-2015 - 07-2015'}
+      start={moment({year: '2015', month: '03'})}
+      end={moment({year: '2015', month: '07'})}
+      initializeWith={date} />);
+    const rangeIndexes = wrapper.instance().getActiveCellsPositions();
+    assert(_.isNumber(rangeIndexes.start), 'return number of start');
+    assert.equal(rangeIndexes.start, 3, 'return index 3 (means March)');
+    assert(_.isNumber(rangeIndexes.end), 'return number of start');
+    assert.equal(rangeIndexes.end, 7, 'return index 7 (means June)');
+  });
+
+  it('return undefined `value` is not provided', () => {
+    const wrapper = mount(<MonthRangePicker
+      initializeWith={date} />);
+    const rangeIndexes = wrapper.instance().getActiveCellsPositions();
+    assert(_.isUndefined(rangeIndexes.start), 'return undefined of start');
+    assert(_.isUndefined(rangeIndexes.end), 'return undefined of end');
+  });
+});
+
+describe('<MonthRangePicker />: isNextPageAvailable', () => {
+  const date = moment('2015-05-01');
+  /* current year 2015 */
+
+  it('has method `isNextPageAvailable`', () => {
+    const wrapper = mount(<MonthRangePicker
+      initializeWith={date} />);
+
+    assert(_.isFunction(wrapper.instance().isNextPageAvailable), 'has the method');
+  });
+
+  it('return false if maxDate in current year', () => {
+    const wrapper = mount(<MonthRangePicker
+      maxDate={moment('2015-11-01')}
+      initializeWith={date} />);
+
+    assert(_.isBoolean(wrapper.instance().isNextPageAvailable()), 'return boolean');
+    assert.isFalse(wrapper.instance().isNextPageAvailable(), 'return false');
+  });
+
+  it('return true if maxDate is in next year', () => {
+    const wrapper = mount(<MonthRangePicker
+      maxDate={moment('2016-11-01')}
+      initializeWith={date} />);
+
+    assert(_.isBoolean(wrapper.instance().isNextPageAvailable()), 'return boolean');
+    assert.isTrue(wrapper.instance().isNextPageAvailable(), 'return true');
+  });
+
+  it('return true if maxDate is in a year after next year', () => {
+    const wrapper = mount(<MonthRangePicker
+      maxDate={moment('2019-11-01')}
+      initializeWith={date} />);
+
+    assert(_.isBoolean(wrapper.instance().isNextPageAvailable()), 'return boolean');
+    assert.isTrue(wrapper.instance().isNextPageAvailable(), 'return true');
+  });
+});
+
+describe('<MonthRangePicker />: isPrevPageAvailable', () => {
+  const date = moment('2015-05-01');
+  /* current year 2015 */
+
+  it('has method `isPrevPageAvailable`', () => {
+    const wrapper = mount(<MonthRangePicker
+      initializeWith={date} />);
+
+    assert(_.isFunction(wrapper.instance().isPrevPageAvailable), 'has the method');
+  });
+
+  it('return false if minDate in current year', () => {
+    const wrapper = mount(<MonthRangePicker
+      minDate={moment('2015-01-01')}
+      initializeWith={date} />);
+
+    assert(_.isBoolean(wrapper.instance().isPrevPageAvailable()), 'return boolean');
+    assert.isFalse(wrapper.instance().isPrevPageAvailable(), 'return false');
+  });
+
+  it('return true if minDate is in previous year', () => {
+    const wrapper = mount(<MonthRangePicker
+      minDate={moment('2014-11-01')}
+      initializeWith={date} />);
+
+    assert(_.isBoolean(wrapper.instance().isPrevPageAvailable()), 'return boolean');
+    assert.isTrue(wrapper.instance().isPrevPageAvailable(), 'return true');
+  });
+
+  it('return true if minDate is in a year before previous year', () => {
+    const wrapper = mount(<MonthRangePicker
+      minDate={moment('2000-11-01')}
+      initializeWith={date} />);
+
+    assert(_.isBoolean(wrapper.instance().isPrevPageAvailable()), 'return boolean');
+    assert.isTrue(wrapper.instance().isPrevPageAvailable(), 'return true');
+  });
+});
+
+describe('<MonthRangePicker />: getCurrentDate', () => {
+  const date = moment('2015-05-01');
+  /* current year 2015 */
+
+  it('has method `getCurrentDate`', () => {
+    const wrapper = mount(<MonthRangePicker
+      initializeWith={date} />);
+
+    assert(_.isFunction(wrapper.instance().getCurrentDate), 'has the method');
+  });
+
+  it('return current year as string', () => {
+    const wrapper = mount(<MonthRangePicker
+      initializeWith={date} />);
+
+    assert(_.isString(wrapper.instance().getCurrentDate()), 'return string');
+    assert.equal(wrapper.instance().getCurrentDate(), '2015', 'return current year');
+  });
+});
+
+describe('<MonthRangePicker />: handleChange', () => {
+  const date = moment('2015-05-01');
+  /* current year 2015 */
+
+  it('has method `handleChange`', () => {
+    const wrapper = mount(<MonthRangePicker
+      initializeWith={date} />);
+
+    assert(_.isFunction(wrapper.instance().handleChange), 'has the method');
+  });
+
+  it('call `onChange` with props argument', () => {
+    const onChangeFake = sinon.fake();
+    const wrapper = mount(<MonthRangePicker
+      onChange={onChangeFake}
+      initializeWith={date} />);
+
+    wrapper.instance().handleChange('click', { itemPosition: 3});
+    const calledWithArgs = onChangeFake.args[0];
+    const start = calledWithArgs[1].value.start;
+    assert(onChangeFake.calledOnce, 'onChange is called once');
+    assert.equal(calledWithArgs[0], 'click', 'correct first argument');
+    assert.isTrue(moment.isMoment(calledWithArgs[1].value.start), 'correct start');
+    assert.equal(start.year(), '2015', 'correct start year');
+    assert.equal(start.month(), '03', 'correct start month');
+    assert.isTrue(!moment.isMoment(calledWithArgs[1].value.end), 'correct end');
+  });
+
+
+  it('call `onChange` with props argument for end month selected', () => {
+    const onChangeFake = sinon.fake();
+    const wrapper = mount(<MonthRangePicker
+      onChange={onChangeFake}
+      value='03-2015 - '
+      start={moment({year: '2015', month: '03'})}
+      initializeWith={date} />);
+
+    wrapper.instance().handleChange('click', { itemPosition: 7});
+    const calledWithArgs = onChangeFake.args[0];
+    const start = calledWithArgs[1].value.start;
+    const end = calledWithArgs[1].value.end;
+    assert(onChangeFake.calledOnce, 'onChange is called once');
+    assert.equal(calledWithArgs[0], 'click', 'correct first argument');
+    assert.isTrue(moment.isMoment(start), 'correct start');
+    assert.equal(start.year(), '2015', 'correct start year');
+    assert.equal(start.month(), '03', 'correct start month');
+
+    assert.isTrue(moment.isMoment(calledWithArgs[1].value.end), 'correct end');
+    assert.equal(end.year(), '2015', 'correct end year');
+    assert.equal(end.month(), '07', 'correct end month');
+  });
+});
+
+describe('<MonthRangePicker />: switchToNextPage', () => {
+  it('shift date 1 year forward', () => {
+    const date = moment('2015-05-01');
+    const wrapper = mount(<MonthRangePicker
+      initializeWith={date} />);
+
+    assert(_.isFunction(wrapper.instance().switchToNextPage), 'has `switchToNextPage` method');
+    assert.equal(wrapper.instance().state.date.year(), 2015, '`date` unshifted yet');
+    wrapper.instance().switchToNextPage();
+    assert.equal(wrapper.instance().state.date.year(), 2015 + 1, '`date` shifted');
+  });
+});
+
+describe('<MonthRangePicker />: switchToPrevPage', () => {
+  it('shift date 1 year backward', () => {
+    const date = moment('2015-05-01');
+    const wrapper = mount(<MonthRangePicker
+      initializeWith={date} />);
+
+    assert(_.isFunction(wrapper.instance().switchToPrevPage), 'has `switchToPrevPage` method');
+    assert.equal(wrapper.instance().state.date.year(), 2015, '`date` unshifted yet');
+    wrapper.instance().switchToPrevPage();
+    assert.equal(wrapper.instance().state.date.year(), 2015 - 1, '`date` shifted');
+  });
+});

--- a/test/pickers/testMonthRangePicker.js
+++ b/test/pickers/testMonthRangePicker.js
@@ -80,6 +80,111 @@ describe('<MonthRangePicker />: getActiveCellPosition', () => {
   });
 });
 
+describe('<MonthRangePicker />: getDisabledPositions', () => {
+  const date = moment('2015-05-01');
+  /* current year 2015 */
+
+  it('works properly if `minDate` prop is provided (which is in current year)', () => {
+    const wrapper = mount(<MonthRangePicker
+      minDate={moment('2015-03-01')}
+      initializeWith={date} />);
+    /* disabled indexes: 0, 1 */
+    assert(_.isArray(wrapper.instance().getDisabledPositions()), 'return array');
+    assert.equal(wrapper.instance().getDisabledPositions().length, 2, 'return array of length 2');
+    wrapper.instance().getDisabledPositions().forEach((month) => {
+      assert(_.isNumber(month), 'contains numbers only');
+    });
+    assert(_.includes(wrapper.instance().getDisabledPositions(), 0), 'month in position 0 is disabled');
+    assert(_.includes(wrapper.instance().getDisabledPositions(), 1), 'month in position 1 is disabled');
+  });
+
+  it('works properly if `minDate` prop is provided (which is before the current year)', () => {
+    const wrapper = mount(<MonthRangePicker
+      minDate={moment('2014-03-01')}
+      initializeWith={date} />);
+    /* disabled indexes: none */
+    assert(_.isUndefined(wrapper.instance().getDisabledPositions()), 'return undefined');
+  });
+
+  it('works properly if `minDate` prop is provided (which is after the current year)', () => {
+    const wrapper = mount(<MonthRangePicker
+      minDate={moment('2016-09-01')}
+      initializeWith={date} />);
+    /* disabled indexes: all */
+    const disabledRange = _.range(0, 12);
+    assert(_.isArray(wrapper.instance().getDisabledPositions()), 'return array');
+    assert.equal(wrapper.instance().getDisabledPositions().length, 12, 'return array of length 12');
+    wrapper.instance().getDisabledPositions().forEach((month) => {
+      assert(_.isNumber(month), 'contains numbers only');
+    });
+    wrapper.instance().getDisabledPositions().forEach((month) => {
+      assert(_.includes(disabledRange, month), 'includes all months');
+    });
+  });
+
+  it('works properly if `maxDate` prop is provided (which is in current year)', () => {
+    const wrapper = mount(<MonthRangePicker
+      maxDate={moment('2015-09-01')}
+      initializeWith={date} />);
+    /* disabled indexes: 9, 10, 11 */
+    assert(_.isArray(wrapper.instance().getDisabledPositions()), 'return array');
+    assert.equal(wrapper.instance().getDisabledPositions().length, 3, 'return array of length 3');
+    wrapper.instance().getDisabledPositions().forEach((month) => {
+      assert(_.isNumber(month), 'contains numbers only');
+    });
+    assert(_.includes(wrapper.instance().getDisabledPositions(), 9), 'month in position 9 is disabled');
+    assert(_.includes(wrapper.instance().getDisabledPositions(), 10), 'month in position 10 is disabled');
+    assert(_.includes(wrapper.instance().getDisabledPositions(), 11), 'month in position 11 is disabled');
+  });
+
+  it('works properly if `maxDate` prop is provided (which is after the current year)', () => {
+    const wrapper = mount(<MonthRangePicker
+      maxDate={moment('2016-03-01')}
+      initializeWith={date} />);
+    /* disabled indexes: none */
+    assert(_.isUndefined(wrapper.instance().getDisabledPositions()), 'return undefined');
+  });
+
+  it('works properly if `maxDate` prop is provided (which is before the current year)', () => {
+    const wrapper = mount(<MonthRangePicker
+      maxDate={moment('2014-09-01')}
+      initializeWith={date} />);
+    /* disabled indexes: all */
+    const disabledRange = _.range(0, 12);
+    assert(_.isArray(wrapper.instance().getDisabledPositions()), 'return array');
+    assert.equal(wrapper.instance().getDisabledPositions().length, 12, 'return array of length 12');
+    wrapper.instance().getDisabledPositions().forEach((month) => {
+      assert(_.isNumber(month), 'contains numbers only');
+    });
+    wrapper.instance().getDisabledPositions().forEach((month) => {
+      assert(_.includes(disabledRange, month), 'includes all months');
+    });
+  });
+
+  it('works properly if `maxDate`, `minDate` props are all provided', () => {
+    const wrapper = mount(<MonthRangePicker
+      maxDate={moment('2015-10-01')}
+      minDate={moment('2015-02-01')}
+      initializeWith={date} />);
+    /* disabled indexes: 0, 10, 11 */
+    assert(_.isArray(wrapper.instance().getDisabledPositions()), 'return array');
+    assert.equal(wrapper.instance().getDisabledPositions().length, 3, 'return array of length 4');
+    wrapper.instance().getDisabledPositions().forEach((month) => {
+      assert(_.isNumber(month), 'contains numbers only');
+    });
+    assert(_.includes(wrapper.instance().getDisabledPositions(), 0), 'month at position 0 is disabled');
+    assert(_.includes(wrapper.instance().getDisabledPositions(), 10), 'month at position 10 is disabled');
+    assert(_.includes(wrapper.instance().getDisabledPositions(), 11), 'month at position 11 is disabled');
+  });
+
+  it('works properly if `maxDate`, `minDate`, `disabled` props are all undefined', () => {
+    const wrapper = mount(<MonthRangePicker
+      initializeWith={date} />);
+    /* disabled indexes: none */
+    assert(_.isUndefined(wrapper.instance().getDisabledPositions()), 'return undefined');
+  });
+});
+
 describe('<MonthRangePicker />: isNextPageAvailable', () => {
   const date = moment('2015-05-01');
   /* current year 2015 */


### PR DESCRIPTION
- implement MonthRangePicker component with same props defined in DateRangePicker 
- move monthpicker.tsx from "/src/pickers/" to "src/pickers/MonthPicker/"
- move "parseDatesRange" from "/src/inputs/DateRangeInput.tsx" to "/src/input/parse.ts", which will be shared in both DateRangeInput and MonthRangeInput
- restructure some function in MonthPicker, which could be shared with MonthRangePicker