### PR TITLE
Mark Dates Bug Fix

### DIFF
--- a/src/pickers/dayPicker/sharedFunctions.ts
+++ b/src/pickers/dayPicker/sharedFunctions.ts
@@ -130,11 +130,7 @@ export function getMarkedDays(
     */
     const fillTo = allDatesNumb.indexOf(1);
     for (var i = 0; i < fillTo; i++) {
-      if (i <= fillTo) {
-        allDatesNumb[i] = 0;
-      } else {
-        break;
-      }
+      allDatesNumb[i] = 0;
     }
 
     const markedIndexes = marked

--- a/src/pickers/dayPicker/sharedFunctions.ts
+++ b/src/pickers/dayPicker/sharedFunctions.ts
@@ -110,7 +110,7 @@ export function getDisabledDays(
   return sortBy(uniq(disabledDays).filter((day) => !isNil(day)));
 }
 
-/** Return day positions that shoud be displayed as marked. */
+/** Return day positions that should be displayed as marked. */
 export function getMarkedDays(
   marked: Moment[],
   currentDate: Moment,
@@ -119,8 +119,22 @@ export function getMarkedDays(
       return [];
     }
     const allDates = buildDays(currentDate, daysOnPage);
-    const allDatesNumb = allDates.map((date) => parseInt(date, 10));
     const activeDayPositions = getDefaultEnabledDayPositions(allDates, currentDate);
+    let allDatesNumb = allDates.map((date) => parseInt(date, 10));
+
+    // The following will clear all dates before the 1st of the current month.
+    // This is to prevent marking days before the 1st, that shouldn't be marked.
+    // If the incorrect dates are marked, instead of the legitimate ones, the legitimate dates
+    // will not be marked at all.
+    const fillTo = allDatesNumb.indexOf(1);
+    for (var i = 0; i < fillTo; i++) {
+      if (i <= fillTo) {
+        allDatesNumb[i] = 0;
+      } else {
+        break;
+      }
+    }
+
     const markedIndexes = marked
       .filter((date) => date.isSame(currentDate, 'month'))
       .map((date) => date.date())

--- a/src/pickers/dayPicker/sharedFunctions.ts
+++ b/src/pickers/dayPicker/sharedFunctions.ts
@@ -120,7 +120,7 @@ export function getMarkedDays(
     }
     const allDates = buildDays(currentDate, daysOnPage);
     const activeDayPositions = getDefaultEnabledDayPositions(allDates, currentDate);
-    let allDatesNumb = allDates.map((date) => parseInt(date, 10));
+    const allDatesNumb = allDates.map((date) => parseInt(date, 10));
 
     /*
      * The following will clear all dates before the 1st of the current month.
@@ -129,7 +129,7 @@ export function getMarkedDays(
      * will not be marked at all.
     */
     const fillTo = allDatesNumb.indexOf(1);
-    for (var i = 0; i < fillTo; i++) {
+    for (let i = 0; i < fillTo; i++) {
       allDatesNumb[i] = 0;
     }
 

--- a/src/pickers/dayPicker/sharedFunctions.ts
+++ b/src/pickers/dayPicker/sharedFunctions.ts
@@ -122,10 +122,12 @@ export function getMarkedDays(
     const activeDayPositions = getDefaultEnabledDayPositions(allDates, currentDate);
     let allDatesNumb = allDates.map((date) => parseInt(date, 10));
 
-    // The following will clear all dates before the 1st of the current month.
-    // This is to prevent marking days before the 1st, that shouldn't be marked.
-    // If the incorrect dates are marked, instead of the legitimate ones, the legitimate dates
-    // will not be marked at all.
+    /*
+     * The following will clear all dates before the 1st of the current month.
+     * This is to prevent marking days before the 1st, that shouldn't be marked.
+     * If the incorrect dates are marked, instead of the legitimate ones, the legitimate dates
+     * will not be marked at all.
+    */
     const fillTo = allDatesNumb.indexOf(1);
     for (var i = 0; i < fillTo; i++) {
       if (i <= fillTo) {


### PR DESCRIPTION
I'm the user who created the PR [Mark dates of interest #77](https://github.com/arfedulov/semantic-ui-calendar-react/pull/77).
I discovered a bug where marking certain dates would not work.

![image](https://user-images.githubusercontent.com/35106956/53106017-dcc84b00-353a-11e9-86fe-35c99b5906bb.png)
**_I tried marking the whole month (1st to 31st)_**

The 30th and 31st would not be marked because there already exists a 30th and 31st that are disabled. So the disabled dates were being marked instead of the active dates.

Fixed with a simple `for` loop that replaces all dates, before the 1st of the month, with `0`.