### PR TITLE
Content items(day/month/year) are wrapped by span tag and classNames are added to headers. No impact, just makes more flexible

### DIFF
--- a/src/views/CalendarBody/Cell.tsx
+++ b/src/views/CalendarBody/Cell.tsx
@@ -74,7 +74,8 @@ class Cell extends React.Component<CellProps, any> {
         style={cellStyle}
         onMouseOver={this.onCellHover}
         onClick={this.onCellClick}>
-        { (marked && !rest.disabled) ? <Label circular color={markColor} key={content}>{content}</Label> : content }
+        { (marked && !rest.disabled) ? <Label circular color={markColor} key={content}>{content}</Label>
+          : <span className = "content-item">{content}</span> }
       </Table.Cell>
     );
   }

--- a/src/views/CalendarHeader/Header.tsx
+++ b/src/views/CalendarHeader/Header.tsx
@@ -45,6 +45,7 @@ function Header(props: HeaderProps) {
     width,
     title,
     localization,
+    className
   } = props;
 
   const cellStyle = {
@@ -62,7 +63,7 @@ function Header(props: HeaderProps) {
   };
 
   return (
-    <Table.Header>
+    <Table.Header className={className}>
       { !isNil(rangeRowContent) && <HeaderRange content={rangeRowContent} /> }
       <Table.Row>
         <Table.HeaderCell style={cellStyle} colSpan='1'>

--- a/src/views/DayView.tsx
+++ b/src/views/DayView.tsx
@@ -47,6 +47,7 @@ class DayView extends BaseCalendarView<DayViewProps, any> {
     return (
       <Calendar ref={(e) => this.calendarNode = findHTMLElement(e)} outlineOnFocus={inline} {...rest}>
         <Header
+          className="day-view-header"
           width={DAY_CALENDAR_ROW_WIDTH}
           displayWeeks
           onNextPageBtnClick={onNextPageBtnClick}

--- a/src/views/MonthView.tsx
+++ b/src/views/MonthView.tsx
@@ -40,6 +40,7 @@ class MonthView extends BaseCalendarView<MonthViewProps, any> {
       ...rest
     } = this.props;
     const headerProps: HeaderProps = {
+      className: "month-view-header",
       onNextPageBtnClick,
       onPrevPageBtnClick,
       hasPrevPage,

--- a/src/views/YearView.tsx
+++ b/src/views/YearView.tsx
@@ -45,6 +45,7 @@ class YearView extends BaseCalendarView<YearViewProps, any> {
     return (
       <Calendar ref={(e) => this.calendarNode = findHTMLElement(e)} outlineOnFocus={inline} {...rest}>
         <Header
+          className="year-view-header"
           title={headerTitle}
           onNextPageBtnClick={onNextPageBtnClick}
           onPrevPageBtnClick={onPrevPageBtnClick}


### PR DESCRIPTION
Content items(day/month/year) are wrapped by span tag to allow applying of styles to item(for example make selection mark as a circle instead of a rectangle etc.)
It can't be done by overwriting of semantic's css
classNames are added to header of views 
No impact