### PR TITLE
feat: change default date format to i18n format

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ You can also set locale for *Input component locally using ``localization`` prop
 | -----| ------------|
 | all that can be used with SUIR Form.Input | |
 | ``value`` | {string} Currently selected value; must have format ``dateFormat``. |
-| ``dateFormat``| {string} Date formatting string. You can use here anything that can be passed to ``moment().format``. Default: ``DD-MM-YYYY``|
+| ``dateFormat``| {string} Date formatting string. You can use here anything that can be passed to ``moment().format``. Default: ``L``|
 | ``popupPosition``| {string} One of ['top left', 'top right', 'bottom left', 'bottom right', 'right center', 'left center', 'top center', 'bottom center']. Default: ``top left``|
 | ``inline`` | {bool} If ``true`` inline picker displayed. Default: ``false`` |
 | ``startMode`` | {string} Display mode to start. One of ['year', 'month', 'day']. Default: ``day``   |
@@ -220,7 +220,7 @@ You can also set locale for *Input component locally using ``localization`` prop
 | all that can be used with SUIR Form.Input | |
 | ``value`` | {string} Currently selected value; must have format ``dateFormat``. |
 | ``dateTimeFormat`` | {string} Datetime formatting string for the input's `value`. You can use any string here that can be passed to ``moment().format``. If provided, it overrides ``dateFormat``, ``divider``, and ``timeFormat``. **Note:** this does not affect the formats used to display the pop-up date and time pickers; it only affects the format of the input's `value` field. Default: ``null`` |
-| ``dateFormat``| {string} Date formatting string. You can use any string here that can be passed to ``moment().format``. Default: ``DD-MM-YYYY``. This formats only the date component of the datetime. |
+| ``dateFormat``| {string} Date formatting string. You can use any string here that can be passed to ``moment().format``. Default: ``L``. This formats only the date component of the datetime. |
 | ``timeFormat`` | {string} One of ["24", "AMPM", "ampm"]. Default: ``"24"`` |
 | ``divider`` | {string} Date and time divider. Default: `` `` |
 | ``popupPosition``| {string} One of ['top left', 'top right', 'bottom left', 'bottom right', 'right center', 'left center', 'top center', 'bottom center']. Default: ``top left``|

--- a/src/inputs/DateInput.tsx
+++ b/src/inputs/DateInput.tsx
@@ -95,7 +95,7 @@ class DateInput extends BaseInput<DateInputProps, DateInputState> {
    */
   public static readonly defaultProps = {
     ...BaseInput.defaultProps,
-    dateFormat: 'DD-MM-YYYY',
+    dateFormat: 'L',
     startMode: 'day',
     preserveViewMode: true,
     icon: 'calendar',

--- a/src/inputs/DateTimeInput.tsx
+++ b/src/inputs/DateTimeInput.tsx
@@ -112,7 +112,7 @@ class DateTimeInput extends BaseInput<DateTimeInputProps, DateTimeInputState> {
    */
   public static readonly defaultProps = {
     ...BaseInput.defaultProps,
-    dateFormat: 'DD-MM-YYYY',
+    dateFormat: 'L',
     timeFormat: '24',
     startMode: 'day',
     divider: ' ',

--- a/src/inputs/DatesRangeInput.tsx
+++ b/src/inputs/DatesRangeInput.tsx
@@ -46,7 +46,7 @@ class DatesRangeInput extends BaseInput<DatesRangeInputProps, BaseInputState> {
    */
   public static readonly defaultProps = {
     ...BaseInput.defaultProps,
-    dateFormat: 'DD-MM-YYYY',
+    dateFormat: 'L',
     icon: 'calendar',
   };
 

--- a/test/inputs/testParse.js
+++ b/test/inputs/testParse.js
@@ -109,7 +109,7 @@ describe('parseValue', () => {
 describe('dateValueToString()', () => {
   it('handles string input value', () => {
     const inputValue = '17-04-2030';
-    const dateFormat = 'DD-MM-YYYY';
+    const dateFormat = 'L';
     const locale = 'en';
 
     const producedValue = dateValueToString(inputValue, dateFormat, locale);
@@ -120,7 +120,7 @@ describe('dateValueToString()', () => {
 
   it('handles Date input value', () => {
     const inputValue = new Date('2015-08-11');
-    const dateFormat = 'DD-MM-YYYY';
+    const dateFormat = 'L';
     const locale = 'en';
 
     const producedValue = dateValueToString(inputValue, dateFormat, locale);
@@ -131,7 +131,7 @@ describe('dateValueToString()', () => {
 
   it('handles Moment input value', () => {
     const inputValue = moment('2015-08-11', 'YYYY-MM-DD');
-    const dateFormat = 'DD-MM-YYYY';
+    const dateFormat = 'L';
     const locale = 'en';
 
     const producedValue = dateValueToString(inputValue, dateFormat, locale);


### PR DESCRIPTION
To be more consistant and permit to developpers to understand easily how to change format, change the default date format to L https://momentjs.com/docs/#/displaying/format/

This change will break tests actually, if you agree with this feat request, i will correct that.