### PR TITLE
fix(BaseInput): crash when using min / max dates

### DIFF
--- a/src/inputs/BaseInput.tsx
+++ b/src/inputs/BaseInput.tsx
@@ -1,4 +1,4 @@
-import { default as moment, Moment } from 'moment';
+import { default as moment, Moment, unitOfTime } from 'moment';
 import * as React from 'react';
 import {
   SemanticTRANSITIONS,
@@ -325,6 +325,36 @@ abstract class BaseInput<P extends BaseInputProps,
 
   protected onInputViewMount = (inputNode: HTMLElement): void => {
     this.inputNode = inputNode;
+  }
+
+  /**
+   * Returns an initial date within the boundaries of minDate and maxDate for given units
+   * @param units {moment.unitOfTime.All[]} Units used to compare, ordered from largest to smallest
+   */
+  protected getInitialDateInBounds = (units: unitOfTime.All[]): Moment => {
+    const {
+      initialDate,
+      minDate,
+      maxDate,
+    } = this.props;
+
+    let date = moment(initialDate);
+    // Check, for each units in order, if minDate has a unit over current inialDate's one,
+    const leftOutOfBounds = minDate && units.reduce(
+      (outOfBound: boolean, unit) => outOfBound || moment(minDate).get(unit) > date.get(unit),
+      false);
+    // Check if maxDate has a unit under initialDate's one
+    const rightOutOfBounds = maxDate && units.reduce(
+      (outOfBound: boolean, unit) => outOfBound || moment(maxDate).get(unit) < date.get(unit),
+      false);
+
+    if (leftOutOfBounds) {
+      date = moment(minDate);
+    } else if (rightOutOfBounds) {
+      date = moment(maxDate);
+    }
+
+    return date;
   }
 }
 

--- a/src/inputs/DateInput.tsx
+++ b/src/inputs/DateInput.tsx
@@ -220,7 +220,11 @@ class DateInput extends BaseInput<DateInputProps, DateInputState> {
       pickerStyle,
       onChange: this.handleSelect,
       onHeaderClick: this.switchToPrevMode,
-      initializeWith: buildValue(this.parseInternalValue(), initialDate, localization, dateFormat),
+      initializeWith: buildValue(
+        this.parseInternalValue(),
+        this.getInitialDateInBounds(['year', 'month']),
+        localization,
+        dateFormat),
       value: buildValue(value, null, localization, dateFormat, null),
       enable: parseArrayOrValue(enable, dateFormat, localization),
       minDate: parseValue(minDate, dateFormat, localization),

--- a/src/inputs/DateTimeInput.tsx
+++ b/src/inputs/DateTimeInput.tsx
@@ -269,7 +269,11 @@ class DateTimeInput extends BaseInput<DateTimeInputProps, DateTimeInputState> {
       closePopup: this.closePopup,
       onChange: this.handleSelect,
       onHeaderClick: this.switchToPrevMode,
-      initializeWith: buildValue(this.parseInternalValue(), initialDate, localization, dateTimeFormat),
+      initializeWith: buildValue(
+        this.parseInternalValue(),
+        this.getInitialDateInBounds(['year', 'month']),
+        localization,
+        dateTimeFormat),
       value: buildValue(value, null, localization, dateTimeFormat, null),
       minDate: parseValue(minDate, dateTimeFormat, localization),
       maxDate: parseValue(maxDate, dateTimeFormat, localization),

--- a/src/inputs/MonthInput.tsx
+++ b/src/inputs/MonthInput.tsx
@@ -99,7 +99,7 @@ class MonthInput extends BaseInput<MonthInputProps, BaseInputState> {
         closePopup={this.closePopup}
         hasHeader={false}
         onChange={this.handleSelect}
-        initializeWith={buildValue(value, initialDate, localization, dateFormat)}
+        initializeWith={buildValue(value, this.getInitialDateInBounds(['year']), localization, dateFormat)}
         value={buildValue(value, null, localization, dateFormat, null)}
         disable={parseArrayOrValue(disable, dateFormat, localization)}
         maxDate={parseValue(maxDate, dateFormat, localization)}

--- a/src/inputs/YearInput.tsx
+++ b/src/inputs/YearInput.tsx
@@ -1,8 +1,8 @@
-import moment from 'moment';
+import moment, { Moment } from 'moment';
 import * as React from 'react';
 
 import YearPicker, {
-  YearPickerOnChangeData,
+  YearPickerOnChangeData, YEARS_ON_PAGE,
 } from '../pickers/YearPicker';
 import InputView from '../views/InputView';
 import BaseInput, {
@@ -77,6 +77,23 @@ class YearInput extends BaseInput<YearInputProps, BaseInputState> {
     );
   }
 
+  protected getInitialDateInBounds = (): Moment => {
+    const {
+      initialDate,
+      minDate,
+      maxDate,
+    } = this.props;
+
+    let date = moment(initialDate);
+    if (minDate && moment(minDate).year() % YEARS_ON_PAGE > date.year() % YEARS_ON_PAGE) {
+      date = moment(minDate);
+    } else if (maxDate && moment(maxDate).year() % YEARS_ON_PAGE < date.year() % YEARS_ON_PAGE) {
+      date = moment(maxDate);
+    }
+
+    return date;
+  }
+
   private getPicker = () => {
     const {
       value,
@@ -96,7 +113,7 @@ class YearInput extends BaseInput<YearInputProps, BaseInputState> {
         onCalendarViewMount={this.onCalendarViewMount}
         closePopup={this.closePopup}
         onChange={this.handleSelect}
-        initializeWith={buildValue(value, initialDate, localization, dateFormat)}
+        initializeWith={buildValue(value, this.getInitialDateInBounds(), localization, dateFormat)}
         value={buildValue(value, null, localization, dateFormat, null)}
         disable={parseArrayOrValue(disable, dateFormat, localization)}
         maxDate={parseValue(maxDate, dateFormat, localization)}

--- a/src/pickers/YearPicker.tsx
+++ b/src/pickers/YearPicker.tsx
@@ -23,7 +23,7 @@ import {
 
 const PAGE_WIDTH = 3;
 const PAGE_HEIGHT = 4;
-const YEARS_ON_PAGE = PAGE_WIDTH * PAGE_HEIGHT;
+export const YEARS_ON_PAGE = PAGE_WIDTH * PAGE_HEIGHT;
 
 type YearPickerProps = BasePickerProps
   & DisableValuesProps

--- a/src/pickers/dayPicker/sharedFunctions.ts
+++ b/src/pickers/dayPicker/sharedFunctions.ts
@@ -206,5 +206,5 @@ if (res) {
 return res.position;
 }
 
-return selectable[0].position;
+return selectable.length > 0 ? selectable[0].position : 0;
 }


### PR DESCRIPTION
Fix Issue #127 
This ensures that initialDate has a month (or year) included between minDate and maxDate.
Although it does not prevent the user from entering inconsistent minDate and maxDate, or reproducing the error by manually disabling all dates in the month. But at least it covers the most frequent use case.

Is BaseInput (and the components that extend it) the right place to do this check? I first looked at _DayPicker_ and its _sharedFunctions_, but since the notion of min/max belongs to BaseInput, it seemed logical to do it there.